### PR TITLE
Created an external-dns chart and adapted documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ Our Kubernetes applications.
 
 First you need to make a copy of `values.example.yaml` to `values.yaml` and edit all values accordingly, then you can just start installing:
 
-```sh
-helm install stable/kube2iam --values values.yaml
-helm install stable/kube-lego --values values.yaml
-
+```console
 helm repo add skyscrapers https://skyscrapers.github.io/charts
+helm install skyscrapers/kube2iam --values values.yaml
+helm install skyscrapers/kube-lego --values values.yaml
 helm install skyscrapers/kubesignin --values values.yaml
 helm install skyscrapers/nginx-ingress --values values.yaml
-# TODO helm install skyscrapers/external-dns --values values.yaml
+helm install skyscrapers/external-dns --values values.yaml
 # TODO helm install skyscrapers/concourse --values values.yaml
 ```
 

--- a/external-dns/.helmignore
+++ b/external-dns/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/external-dns/Chart.yaml
+++ b/external-dns/Chart.yaml
@@ -1,0 +1,16 @@
+name: external-dns
+version: 0.0.1
+description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services
+keywords:
+  - dns
+  - external-dns
+  - route53
+home: https://github.com/kubernetes-incubator/external-dns
+sources:
+  - https://github.com/kubernetes-incubator/external-dns
+  - https://github.com/kubernetes/charts
+  - https://github.com/skyscrapers/charts
+maintainers:
+  - name: skyscrapers
+    email: hello@skyscrapers.eu
+engine: gotpl

--- a/external-dns/README.md
+++ b/external-dns/README.md
@@ -1,57 +1,57 @@
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: external-dns
-spec:
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app: external-dns
-      annotations:
-        iam.amazonaws.com/role: arn:aws:iam::847239549153:role/external_dns_controller
-    spec:
-      serviceAccountName: external-dns
-      containers:
-      - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0
-        args:
-          - --source=service
-          - --source=ingress
-          - --provider=aws
-          - --registry=txt
-          - --txt-owner-id=external-dns-controller
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: external-dns
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: external-dns
-subjects:
-  - kind: ServiceAccount
-    name: external-dns
-    namespace: default
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: external-dns
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: external-dns
-rules:
-- apiGroups:
-  - ""
-  - "extensions"
-  resources:
-  - services
-  - ingresses
-  verbs:
-  - list
+# A helm chart to install external-dns
+
+Installs [external-dns](https://github.com/kubernetes-incubator/external-dns) to manage external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
+
+## TL;DR;
+
+```console
+$ helm install skyscrapers/external-dns -f values.yaml
+```
+
+## Introduction
+
+This chart bootstraps a [external-dns](https://github.com/kubernetes-incubator/external-dns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.6+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install skyscrapers/external-dns --name my-release -f values.yaml
+```
+
+The command deploys external-dns on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the external-dns chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`ExternalDNS.IAMRoleARN` | The IAM Role ARN to use to manage Route53 | (required)
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install skyscrapers/external-dns --name my-release \
+  --set=ExternalDNS.IAMRoleARN=arn:aws:iam::0123456789:role/external-dns-role
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install skyscrapers/external-dns --name my-release -f values.yaml
+```

--- a/external-dns/templates/_helpers.tpl
+++ b/external-dns/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/external-dns/templates/deployment.yaml
+++ b/external-dns/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        iam.amazonaws.com/role: {{ .Values.ExternalDNS.IAMRoleARN }}
+    spec:
+      serviceAccountName: {{ template "fullname" . }}
+      containers:
+      - name: {{ template "fullname" . }}
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0
+        args:
+          - --source=service
+          - --source=ingress
+          - --provider=aws
+          - --registry=txt
+          - --txt-owner-id=external-dns-controller

--- a/external-dns/templates/rbac.yaml
+++ b/external-dns/templates/rbac.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  - "extensions"
+  resources:
+  - services
+  - ingresses
+  verbs:
+  - list

--- a/kubesignin/README.md
+++ b/kubesignin/README.md
@@ -1,4 +1,4 @@
-## A Helm Chart for Kubesignin
+# A Helm Chart for Kubesignin
 
 Originates from https://github.com/skyscrapers/kubesignin
 

--- a/values.example.yaml
+++ b/values.example.yaml
@@ -25,4 +25,13 @@ config:
 # Nginx-ingress
 controller:
   image:
-    tag: "0.9.0-beta.3"
+    tag: "0.9.0-beta.7"
+  publishService:
+    enabled: true
+  rbac:
+    enabled: true
+  stats:
+    enabled: true
+
+ExternalDNS:
+  IAMRoleARN: <IAM_ROLE_ARN>


### PR DESCRIPTION
Now `external-dns` has its own chart so we can install it with helm with:
```
helm install skyscrapers/external-dns
```