### PR TITLE
Verb create cannot have an associated resource name

### DIFF
--- a/nginx-ingress/templates/controller-role.yaml
+++ b/nginx-ingress/templates/controller-role.yaml
@@ -23,9 +23,15 @@ rules:
       # when launching the nginx-ingress-controller.
       - "ingress-controller-leader-nginx"
     verbs:
-      - create
-      - get
       - update
+      - delete
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
This prevented the nginx ingress controller to work properly, as it couldn't assign any leader.