### PR TITLE
Fix for external-dns deleting wrong records

### DIFF
--- a/external-dns/README.md
+++ b/external-dns/README.md
@@ -42,12 +42,14 @@ The following tables lists the configurable parameters of the external-dns chart
 Parameter | Description | Default
 --- | --- | ---
 `ExternalDNS.IAMRoleARN` | The IAM Role ARN to use to manage Route53 | (required)
+`ExternalDNS.TXTOwnerId` | Unique identier to specify which records can be managed | (required)
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install skyscrapers/external-dns --name my-release \
-  --set=ExternalDNS.IAMRoleARN=arn:aws:iam::0123456789:role/external-dns-role
+  --set=ExternalDNS.IAMRoleARN=arn:aws:iam::0123456789:role/external-dns-role \
+  --set=ExternalDNS.TXTOwnerId=production
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/external-dns/README.md
+++ b/external-dns/README.md
@@ -49,7 +49,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm install skyscrapers/external-dns --name my-release \
   --set=ExternalDNS.IAMRoleARN=arn:aws:iam::0123456789:role/external-dns-role \
-  --set=ExternalDNS.TXTOwnerId=production
+  --set=ExternalDNS.TXTOwnerId=external-dns-production
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/external-dns/templates/deployment.yaml
+++ b/external-dns/templates/deployment.yaml
@@ -27,4 +27,4 @@ spec:
           - --source=ingress
           - --provider=aws
           - --registry=txt
-          - --txt-owner-id=external-dns-controller
+          - --txt-owner-id=external-dns-{{ .Values.ExternalDNS.TXTOwnerId }}

--- a/external-dns/templates/deployment.yaml
+++ b/external-dns/templates/deployment.yaml
@@ -27,4 +27,4 @@ spec:
           - --source=ingress
           - --provider=aws
           - --registry=txt
-          - --txt-owner-id=external-dns-{{ .Values.ExternalDNS.TXTOwnerId }}
+          - --txt-owner-id={{ .Values.ExternalDNS.TXTOwnerId }}


### PR DESCRIPTION
Production cluster keeps deleting the staging records and vica versa. We need to make the txt owner id value unique per cluster