### PR TITLE
Opsgenie Heartbeat proxy

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: cluster-monitoring
-version: 0.0.2
+version: 0.0.3
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/README.md
+++ b/cluster-monitoring/README.md
@@ -14,7 +14,7 @@ Installs the following components for a complete k8s cluster monitoring setup:
 -   [prometheus-operator](https://github.com/coreos/prometheus-operatortree/master/helm/prometheus-operator)
 -   [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/helm/kube-prometheus), which includes a Prometheus & Alertmanager TPR with some exporters for k8s cluster monitoring.
 -   [grafana](https://github.com/coreos/prometheus-operator/tree/master/helm/grafana)
--   opsgenie-heartbeat-proxy
+-   [opsgenie-heartbeat-proxy](https://github.com/traum-ferienwohnungen/opsgenie-heartbeat-proxy)
 
 ## Prerequisites
   - Kubernetes 1.6+
@@ -55,9 +55,9 @@ Parameter | Description | Default
 `opsgenieHeartbeatProxy.port` | Port to run container on | `8080`
 `opsgenieHeartbeatProxy.replicas` | Amount of replicas| `3`
 `opsgenieHeartbeatProxy.imageTag` | Image tag | `v0.0.2`
-`opsgenieHeartbeatProxy.opsgenie_api_key` | Opsgenie API Key | ``
-`opsgenieHeartbeatProxy.heartbeat_name` | Opsgenie Heartbeat name | ``
-`opsgenieHeartbeatProxy.resources` | Pod resource requests & limits | ``
+`opsgenieHeartbeatProxy.opsgenie_api_key` | Opsgenie API Key | `""`
+`opsgenieHeartbeatProxy.heartbeat_name` | Opsgenie Heartbeat name | `""`
+`opsgenieHeartbeatProxy.resources` | Pod resource requests & limits | `CPU: 128m, Memory: 128Mi`
 
 Upstream configuration can be found here:
 -   [prometheus-operator configuration](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md#configuration)

--- a/cluster-monitoring/README.md
+++ b/cluster-monitoring/README.md
@@ -14,6 +14,7 @@ Installs the following components for a complete k8s cluster monitoring setup:
 -   [prometheus-operator](https://github.com/coreos/prometheus-operatortree/master/helm/prometheus-operator)
 -   [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/helm/kube-prometheus), which includes a Prometheus & Alertmanager TPR with some exporters for k8s cluster monitoring.
 -   [grafana](https://github.com/coreos/prometheus-operator/tree/master/helm/grafana)
+-   opsgenie-heartbeat-proxy
 
 ## Prerequisites
   - Kubernetes 1.6+
@@ -42,7 +43,23 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-As this chart itself doesn't provide any configurable parameters on it's own (yet), everything is taken over from upstream:
+This charts only has configurable parameters for opsgenie-heartbeat-proxy, everything else is taken from upstream:
+
+The following tables lists the configurable parameters of the prometheus-operator chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`opsgenieHeartbeatProxy.image` | Image | `traumfewo/opsgenie-heartbeat-proxy`
+`opsgenieHeartbeatProxy.imageTag` | Image tag | `v0.0.2`
+`opsgenieHeartbeatProxy.imagePullPolicy` | Image pull policy | `IfNotPresent`
+`opsgenieHeartbeatProxy.port` | Port to run container on | `8080`
+`opsgenieHeartbeatProxy.replicas` | Amount of replicas| `3`
+`opsgenieHeartbeatProxy.imageTag` | Image tag | `v0.0.2`
+`opsgenieHeartbeatProxy.opsgenie_api_key` | Opsgenie API Key | ``
+`opsgenieHeartbeatProxy.heartbeat_name` | Opsgenie Heartbeat name | ``
+`opsgenieHeartbeatProxy.resources` | Pod resource requests & limits | ``
+
+Upstream configuration can be found here:
 -   [prometheus-operator configuration](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md#configuration)
 -   [prometheus configuration](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/README.md#configuration)
 -   [alertmanager configuration](https://github.com/coreos/prometheus-operator/blob/master/helm/alertmanager/README.md#configuration)

--- a/cluster-monitoring/templates/_helpers.tpl
+++ b/cluster-monitoring/templates/_helpers.tpl
@@ -16,6 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "opsgenie-heartbeat-proxy.fullname" -}}
-{{- $name := default "opsgenie-heartbeat-proxy" .Values.opsgenie-heartbeat-proxy.nameOverride -}}
+{{- $name := default "opsgenie-heartbeat-proxy" index .Values "opsgenie-heartbeat-proxy" "nameOverride" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/cluster-monitoring/templates/_helpers.tpl
+++ b/cluster-monitoring/templates/_helpers.tpl
@@ -14,3 +14,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "opsgenie-heartbeat-proxy.fullname" -}}
+{{- $name := default "opsgenie-heartbeat-proxy" .Values.opsgenie-heartbeat-proxy.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/cluster-monitoring/templates/_helpers.tpl
+++ b/cluster-monitoring/templates/_helpers.tpl
@@ -15,7 +15,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "opsgenie-heartbeat-proxy.fullname" -}}
-{{- $name := default "opsgenie-heartbeat-proxy" index .Values "opsgenie-heartbeat-proxy" "nameOverride" -}}
+{{- define "opsgenieHeartbeatProxy.fullname" -}}
+{{- $name := default "opsgenie-heartbeat-proxy" .Values.opsgenieHeartbeatProxy.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/cluster-monitoring/templates/configmap.yaml
+++ b/cluster-monitoring/templates/configmap.yaml
@@ -8,5 +8,4 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  opsgenie_api_key: {{ .Values.opsgenieHeartbeatProxy.opsgenie_api_key | quote }}
   heartbeat_name: {{ .Values.opsgenieHeartbeatProxy.heartbeat_name | quote }}

--- a/cluster-monitoring/templates/configmap.yaml
+++ b/cluster-monitoring/templates/configmap.yaml
@@ -8,5 +8,5 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  opsgenie_api_key: {{ .Values.opsgenie-heartbeat-proxy.opsgenie_api_key | quote }}
-  heartbeat_name: {{ .Values.opsgenie_api_key.heartbeat_name | quote }}
+  opsgenie_api_key: {{ index .Values "opsgenie-heartbeat-proxy" "opsgenie_api_key" | quote }}
+  heartbeat_name: {{ index .Values "opsgenie_api_key" "heartbeat_name" | quote }}

--- a/cluster-monitoring/templates/configmap.yaml
+++ b/cluster-monitoring/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  opsgenie_api_key: {{ .Values.opsgenie-heartbeat-proxy.opsgenie_api_key | quote }}
+  heartbeat_name: {{ .Values.opsgenie_api_key.heartbeat_name | quote }}

--- a/cluster-monitoring/templates/opsgenie-heartbeat-proxy-deployment.yaml
+++ b/cluster-monitoring/templates/opsgenie-heartbeat-proxy-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+  name: {{ template "opsgenieHeartbeatProxy.fullname" . }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: {{ index .Values "opsgenie-heartbeat-proxy" "replicas" }}
+  replicas: {{ .Values.opsgenieHeartbeatProxy.replicas }}
   template:
     metadata:
       labels:
@@ -18,34 +18,34 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
-          image: "{{ index .Values "opsgenie-heartbeat-proxy" "image" }}:{{ index .Values "opsgenie-heartbeat-proxy" "imageTag" }}"
-          imagePullPolicy: {{ default "" index .Values "opsgenie-heartbeat-proxy" "imagePullPolicy" | quote }}
+        - name: {{ template "opsgenieHeartbeatProxy.fullname" . }}
+          image: "{{ .Values.opsgenieHeartbeatProxy.image }}:{{ .Values.opsgenieHeartbeatProxy.imageTag }}"
+          imagePullPolicy: {{ default "" .Values.opsgenieHeartbeatProxy.imagePullPolicy | quote }}
           env:
             - name: OPSGENIE_API_KEY
               valueFrom:
-                configMapKeyRef:
-                  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+                secretKeyRef:
+                  name: {{ template "opsgenieHeartbeatProxy.fullname" . }}
                   key: opsgenie_api_key
             - name: HEARTBEAT_NAME
               valueFrom:
                 configMapKeyRef:
-                  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+                  name: {{ template "opsgenieHeartbeatProxy.fullname" . }}
                   key: heartbeat_name
           ports:
-            - name: opsgenie-heartbeat-proxy
-              containerPort: {{ index .Values "opsgenie-heartbeat-proxy" "port" }}
+            - name: opsgenie-proxy
+              containerPort: {{ .Values.opsgenieHeartbeatProxy.port }}
           livenessProbe:
             tcpSocket:
-              port: opsgenie-heartbeat-proxy
+              port: opsgenie-proxy
             initialDelaySeconds: 10
             timeoutSeconds: 5
           readinessProbe:
             tcpSocket:
-              port: opsgenie-heartbeat-proxy
+              port: opsgenie-proxy
             initialDelaySeconds: 10
             timeoutSeconds: 5
           resources:
-{{ toYaml index .Values "opsgenie-heartbeat-proxy" "resources" | indent 12 }}
+{{ toYaml .Values.opsgenieHeartbeatProxy.resources | indent 12 }}
       imagePullSecrets:
         - name: regsecret

--- a/cluster-monitoring/templates/opsgenie-heartbeat-proxy-deployment.yaml
+++ b/cluster-monitoring/templates/opsgenie-heartbeat-proxy-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: opsgenie-heartbeat-proxy
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.opsgenie-heartbeat-proxy.replicas }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "opsgenie-heartbeat-proxy"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+          image: "{{ .Values.opsgenie-heartbeat-proxy.image }}:{{ .Values.opsgenie-heartbeat-proxy.imageTag }}"
+          imagePullPolicy: {{ default "" .Values.opsgenie-heartbeat-proxy.imagePullPolicy | quote }}
+          env:
+            - name: OPSGENIE_API_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+                  key: opsgenie_api_key
+            - name: HEARTBEAT_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+                  key: heartbeat_name
+          ports:
+            - name: opsgenie-heartbeat-proxy
+              containerPort: {{ .Values.opsgenie-heartbeat-proxy.port }}
+          livenessProbe:
+            tcpSocket:
+              port: opsgenie-heartbeat-proxy
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: opsgenie-heartbeat-proxy
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          resources:
+{{ toYaml .Values.opsgenie-heartbeat-proxy.resources | indent 12 }}
+      imagePullSecrets:
+        - name: regsecret

--- a/cluster-monitoring/templates/opsgenie-heartbeat-proxy-deployment.yaml
+++ b/cluster-monitoring/templates/opsgenie-heartbeat-proxy-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: {{ .Values.opsgenie-heartbeat-proxy.replicas }}
+  replicas: {{ index .Values "opsgenie-heartbeat-proxy" "replicas" }}
   template:
     metadata:
       labels:
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
         - name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
-          image: "{{ .Values.opsgenie-heartbeat-proxy.image }}:{{ .Values.opsgenie-heartbeat-proxy.imageTag }}"
-          imagePullPolicy: {{ default "" .Values.opsgenie-heartbeat-proxy.imagePullPolicy | quote }}
+          image: "{{ index .Values "opsgenie-heartbeat-proxy" "image" }}:{{ index .Values "opsgenie-heartbeat-proxy" "imageTag" }}"
+          imagePullPolicy: {{ default "" index .Values "opsgenie-heartbeat-proxy" "imagePullPolicy" | quote }}
           env:
             - name: OPSGENIE_API_KEY
               valueFrom:
@@ -34,7 +34,7 @@ spec:
                   key: heartbeat_name
           ports:
             - name: opsgenie-heartbeat-proxy
-              containerPort: {{ .Values.opsgenie-heartbeat-proxy.port }}
+              containerPort: {{ index .Values "opsgenie-heartbeat-proxy" "port" }}
           livenessProbe:
             tcpSocket:
               port: opsgenie-heartbeat-proxy
@@ -46,6 +46,6 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 5
           resources:
-{{ toYaml .Values.opsgenie-heartbeat-proxy.resources | indent 12 }}
+{{ toYaml index .Values "opsgenie-heartbeat-proxy" "resources" | indent 12 }}
       imagePullSecrets:
         - name: regsecret

--- a/cluster-monitoring/templates/opsgenie-heartbeat-proxy-service.yaml
+++ b/cluster-monitoring/templates/opsgenie-heartbeat-proxy-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: opsgenie-heartbeat-proxy
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.opsgenie-heartbeat-proxy.port }}
+  selector:
+    app: {{ template "fullname" . }}
+    component: "opsgenie-heartbeat-proxy"
+    release: {{ .Release.Name }}

--- a/cluster-monitoring/templates/opsgenie-heartbeat-proxy-service.yaml
+++ b/cluster-monitoring/templates/opsgenie-heartbeat-proxy-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "opsgenie-heartbeat-proxy.fullname" . }}
+  name: {{ template "opsgenieHeartbeatProxy.fullname" . }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -12,7 +12,7 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: {{ index .Values "opsgenie-heartbeat-proxy" "port" }}
+      targetPort: {{ .Values.opsgenieHeartbeatProxy.port }}
   selector:
     app: {{ template "fullname" . }}
     component: "opsgenie-heartbeat-proxy"

--- a/cluster-monitoring/templates/opsgenie-heartbeat-proxy-service.yaml
+++ b/cluster-monitoring/templates/opsgenie-heartbeat-proxy-service.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: {{ .Values.opsgenie-heartbeat-proxy.port }}
+      targetPort: {{ index .Values "opsgenie-heartbeat-proxy" "port" }}
   selector:
     app: {{ template "fullname" . }}
     component: "opsgenie-heartbeat-proxy"

--- a/cluster-monitoring/templates/secrets.yaml
+++ b/cluster-monitoring/templates/secrets.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ template "opsgenieHeartbeatProxy.fullname" . }}
   labels:
@@ -7,6 +7,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+type: Opaque
 data:
-  opsgenie_api_key: {{ .Values.opsgenieHeartbeatProxy.opsgenie_api_key | quote }}
-  heartbeat_name: {{ .Values.opsgenieHeartbeatProxy.heartbeat_name | quote }}
+    opsgenie_api_key: {{ .Values.opsgenieHeartbeatProxy.opsgenie_api_key | b64enc | quote }}

--- a/cluster-monitoring/values.yaml
+++ b/cluster-monitoring/values.yaml
@@ -3,5 +3,9 @@ opsgenieHeartbeatProxy:
     imageTag: "v0.0.2"
     port: "8080"
     replicas: 3
+    resources:
+        requests:
+            cpu: "128m"
+            memory: "128Mi"
     #opsgenie_api_key:
     #heartbeat_name:

--- a/cluster-monitoring/values.yaml
+++ b/cluster-monitoring/values.yaml
@@ -1,0 +1,7 @@
+opsgenie-heartbeat-proxy:
+    image: "traumfewo/opsgenie-heartbeat-proxy"
+    imageTag: "v0.0.2"
+    port: "8080"
+    replicas: 3
+    #opsgenie_api_key:
+    #heartbeat_name:

--- a/cluster-monitoring/values.yaml
+++ b/cluster-monitoring/values.yaml
@@ -1,4 +1,4 @@
-opsgenie-heartbeat-proxy:
+opsgenieHeartbeatProxy:
     image: "traumfewo/opsgenie-heartbeat-proxy"
     imageTag: "v0.0.2"
     port: "8080"


### PR DESCRIPTION
This adds the deployment of Opsgenie Heartbeat proxy to cluster monitoring.
This deploys 3 pods of Opsgenie Heartbeat proxy + a service to have a central endpoint. In our alertmanager rules we can specify that endpoint.

I tested this on our test cluster.
