### PR TITLE
Add -u parameter to package of helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ prep:
 	wget -q https://skyscrapers.github.io/charts/index.yaml -O old-index.yaml
 
 package:
-	$(foreach chart,$(CHARTS),(helm package $(chart) -d ./charts --save=false) &&) :
+	$(foreach chart,$(CHARTS),(helm package $(chart) -u -d ./charts --save=false) &&) :
 
 index:
 	@helm repo index ./charts --url https://skyscrapers.github.io/charts --merge old-index.yaml


### PR DESCRIPTION
The -u parameter of helm package does an update of the dependencies before updating. This makes sure we don't have to add those dependencies to the git repo.

More info about helm package
```
Usage:
  helm package [flags] [CHART_PATH] [...]

Flags:
      --app-version string   set the appVersion on the chart to this version
  -u, --dependency-update    update dependencies from "requirements.yaml" to dir "charts/" before packaging
  -d, --destination string   location to write the chart. (default ".")
      --key string           name of the key to use when signing. Used if --sign is true
      --keyring string       location of a public keyring (default "/Users/mattias/.gnupg/pubring.gpg")
      --save                 save packaged chart to local chart repository (default true)
      --sign                 use a PGP private key to sign this package
      --version string       set the version on the chart to this semver version

Global Flags:
      --debug                     enable verbose output
      --home string               location of your Helm config. Overrides $HELM_HOME (default "/Users/mattias/.helm")
      --host string               address of Tiller. Overrides $HELM_HOST
      --kube-context string       name of the kubeconfig context to use
      --tiller-namespace string   namespace of Tiller (default "kube-system")
````

This solves the following error in our cd.
```
Error: found in requirements.yaml, but missing in charts/ directory: kube-prometheus

```