### PR TITLE
Added extra values into kubesignin chart to provide the groups that have admin access to the cluster

### DIFF
--- a/kubesignin/templates/rolebinding.yaml
+++ b/kubesignin/templates/rolebinding.yaml
@@ -16,6 +16,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "dex.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.Kubesignin.K8sAdminsGroups }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -26,6 +27,9 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
+{{- range .Values.Kubesignin.K8sAdminsGroups }}
   - kind: Group
-    name: k8s-admins
+    name: {{ . }}
     apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/kubesignin/values.yaml
+++ b/kubesignin/values.yaml
@@ -66,4 +66,9 @@ Kubesignin:
   Cpu: "512m"
   Replicas: 1
 
+  # Tokens that have these groups as claims will be given admin access to the cluster
+  K8sAdminsGroups: []
+    # - "myorg:myteam"
+    # - "otherorg:someteam"
+
   # Debug: true


### PR DESCRIPTION
## Reasons:

- Dex has changed slightly how it provides GH group claims, it now provides them as `<gh_org>:<gh_team>`, so that needed to be updated.
- We want to provide admin access also to our customers, so we have to be able to add extra groups to the ClusterRoleBinding object.
- Can't infer the groups from the Dex values, as they are two different things, with different meanings. In Dex, the teams are a simple whitelist of who can get a token, and it could even be empty, so everyone from a GitHub organization could get one. In this commit I've added the groups that will be allowed admin access.