### PR TITLE
Rebase fluentd chart from upstream and add environment variable

### DIFF
--- a/fluentd-cloudwatch/Chart.yaml
+++ b/fluentd-cloudwatch/Chart.yaml
@@ -1,7 +1,8 @@
 name: fluentd-cloudwatch
-version: 0.2.3
-appVersion: 0.1.1
+version: 0.4.2
+appVersion: v0.12.33-cloudwatch
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
+home: https://www.fluentd.org/
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 keywords:
 - fluentd

--- a/fluentd-cloudwatch/README.md
+++ b/fluentd-cloudwatch/README.md
@@ -42,26 +42,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Fluentd Cloudwatch chart and their default values.
+The following table lists the configurable parameters of the Fluentd Cloudwatch chart and their default values.
 
-| Parameter                       | Description                                | Default                                                    |
-| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
-| `image`                         | Image                                      | `fluent/fluentd-kubernetes-daemonset`                      |
-| `imageTag`                      | Image tag                                  | `v0.12.33-cloudwatch`                                      |
-| `imagePullPolicy`               | Image pull policy                          | `Always` if `imageTag` is `imagePullPolicy`                |
-| `resources.limits.cpu`          | CPU limit                                  | `100m`                                                     |
-| `resources.limits.memory`       | Memory limit                               | `200Mi`                                                    |
-| `resources.requests.cpu`        | CPU request                                | `100m`                                                     |
-| `resources.requests.memory`     | Memory request                             | `200Mi`                                                    |
-| `hostNetwork`                   | Host network                               | `false`                                                    |
-| `annotations` (removed for now) | Annotations                                | `nil`                                                      |
-| `awsRegion`                     | AWS Cloudwatch region                      | `us-east-1`                                                |
-| `awsRole`                       | AWS IAM Role To Use                        | `nil`                                                      |
-| `fluentdConfig`                 | Fluentd configuration                      | `example configuration`                                    |
-| `logGroupName`                  | AWS Cloudwatch log group                   | `kubernetes`                                               |
-| `rbac.create`                   | If true, create & use RBAC resources       | `false`                                                    |
-| `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true) | `default`                                |
-| `tolerations`                   | Add tolerations                            | `[]`                                                       |
+| Parameter                       | Description                                                  | Default                               |
+| ------------------------------- | ------------------------------------------------------------ | --------------------------------------|
+| `image.repository`              | Image repository                                             | `fluent/fluentd-kubernetes-daemonset` |
+| `image.tag`                     | Image tag                                                    | `v0.12.33-cloudwatch`                 |
+| `image.pullPolicy`              | Image pull policy                                            | `IfNotPresent`                        |
+| `resources.limits.cpu`          | CPU limit                                                    | `100m`                                |
+| `resources.limits.memory`       | Memory limit                                                 | `200Mi`                               |
+| `resources.requests.cpu`        | CPU request                                                  | `100m`                                |
+| `resources.requests.memory`     | Memory request                                               | `200Mi`                               |
+| `hostNetwork`                   | Host network                                                 | `false`                               |
+| `annotations` (removed for now) | Annotations                                                  | `nil`                                 |
+| `awsRegion`                     | AWS Cloudwatch region                                        | `us-east-1`                           |
+| `awsRole`                       | AWS IAM Role To Use                                          | `nil`                                 |
+| `fluentdConfig`                 | Fluentd configuration                                        | `example configuration`               |
+| `logGroupName`                  | AWS Cloudwatch log group                                     | `kubernetes`                          |
+| `rbac.create`                   | If true, create & use RBAC resources                         | `false`                               |
+| `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true) | `default`                             |
+| `tolerations`                   | Add tolerations                                              | `[]`                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/fluentd-cloudwatch/templates/daemonset.yaml
@@ -20,10 +20,19 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "fluentd-cloudwatch.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      initContainers:
+        - name: copy-fluentd-config
+          image: busybox
+          command: ['sh', '-c', 'cp /config-volume/* /etc/fluentd']
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: config
+              mountPath: /etc/fluentd
       containers:
       - name: {{ template "fluentd-cloudwatch.fullname" . }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         #hostNetwork: {{ default false .Values.hostNetwork }}
         env:
         - name: AWS_REGION
@@ -42,9 +51,6 @@ spec:
               key: aws_secret_access_key
               name: {{ template "fluentd-cloudwatch.fullname" . }}
 {{- end }}
-{{- if .Values.fluentdEnv }}
-{{ toYaml .Values.fluentdEnv | indent 8 }}
-{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
@@ -53,7 +59,7 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        - name: config-volume
+        - name: config
           mountPath: /fluentd/etc
       terminationGracePeriodSeconds: 30
       volumes:
@@ -63,6 +69,8 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: config
+        emptyDir: {}
       - name: config-volume
         configMap:
           name: {{ template "fluentd-cloudwatch.fullname" . }}

--- a/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/fluentd-cloudwatch/templates/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
           value: {{ .Values.awsRegion }}
         - name: LOG_GROUP_NAME
           value: {{ .Values.logGroupName }}
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
 {{- if not .Values.awsRole }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:

--- a/fluentd-cloudwatch/values.yaml
+++ b/fluentd-cloudwatch/values.yaml
@@ -1,11 +1,10 @@
-image: fluent/fluentd-kubernetes-daemonset
-imageTag: v0.12.33-cloudwatch
-
+image:
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v0.12.33-cloudwatch
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
-imagePullPolicy: IfNotPresent
-
+  pullPolicy: IfNotPresent
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -39,18 +38,6 @@ rbac:
   ## Ignored if rbac.create is true
   serviceAccountName: default
 
-## Add extra fluentd container ENV variables if specified
-fluentdEnv:
-    ## Add extra fluentd ENV vars to work around an entrypoint.sh bug where the
-    ## container tries to update it's own ConfigMap (RO). These aren't used in
-    ## our config and thus the value doesn't matter.
-    ## https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
-    ## https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/templates/entrypoint.sh#L5-L11
-  - name: FLUENT_ELASTICSEARCH_USER
-    value: none
-  - name: FLUENT_ELASTICSEARCH_PASSWORD
-    value: none
-
 fluentdConfig: |
   <match fluent.**>
     type null
@@ -58,6 +45,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     path /var/log/containers/*.log
     pos_file /var/log/fluentd-containers.log.pos
     time_format %Y-%m-%dT%H:%M:%S.%NZ
@@ -68,6 +56,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
     time_format %Y-%m-%d %H:%M:%S
     path /var/log/salt/minion
@@ -77,6 +66,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format syslog
     path /var/log/startupscript.log
     pos_file /var/log/fluentd-startupscript.log.pos
@@ -85,6 +75,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
     path /var/log/docker.log
     pos_file /var/log/fluentd-docker.log.pos
@@ -93,6 +84,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format none
     path /var/log/etcd.log
     pos_file /var/log/fluentd-etcd.log.pos
@@ -101,6 +93,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/kubelet.log
@@ -110,6 +103,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/kube-proxy.log
@@ -119,6 +113,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/kube-apiserver.log
@@ -128,6 +123,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/kube-controller-manager.log
@@ -137,6 +133,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/kube-scheduler.log
@@ -146,6 +143,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/rescheduler.log
@@ -155,6 +153,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/glbc.log
@@ -164,6 +163,7 @@ fluentdConfig: |
 
   <source>
     type tail
+    enable_stat_watcher false
     format kubernetes
     multiline_flush_interval 5s
     path /var/log/cluster-autoscaler.log


### PR DESCRIPTION
The bug that forced us to use our own fluentd-cloudwatch chart was already [fixed upstream](https://github.com/kubernetes/charts/pull/5210), so I've rebased our copy from upstream again.

Then I've also added the `K8S_NODE_NAME` environment variable to the daemonset, [as suggested in the `kubernetes_metadata_filter` Fluentd module](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes), to reduce cache misses while querying the kubernetes API.

That environment variable can also be useful to add the node name in the log tags in Fluentd.

I'll also check if I can create a PR upstream to also add that environment variable.