### PR TITLE
Use resources for oidc group matching instead of claims regex

### DIFF
--- a/kubesignin/templates/proxy-deployment.yaml
+++ b/kubesignin/templates/proxy-deployment.yaml
@@ -30,9 +30,8 @@ spec:
             - "--enable-refresh-tokens=true"
             - "--encryption-key={{ randAlphaNum 32 }}"
             - "--upstream-url={{ $value.upstreamURL }}"
-            - "--resources=uri=/*"
+            - "--resources=uri=/*|groups={{ $value.oidc.groups }}"
             - "--scopes=groups"
-            - "--match-claims=groups={{ $value.oidc.groups }}"
 {{- if $value.extraArgs }}
 {{ toYaml $value.extraArgs | indent 12 }}
 {{- end }}


### PR DESCRIPTION
Related issue: skyscrapers/runtime#3

To be rolled out together with: skyscrapers/terraform-kubernetes#69

Use resources for oidc group matching instead of claims regex. This is the preferred usage of checking group access, following the docs. My regex-based approach in the claims was sort of a hack and probably more error prone.

Using the `resources` parameter, this also allows for more fine-grained access control (via roles, different uri's etc.) in the future.