### PR TITLE
Add customizable upstream timeout for oidc proxies

### DIFF
--- a/kubesignin/templates/proxy-deployment.yaml
+++ b/kubesignin/templates/proxy-deployment.yaml
@@ -32,6 +32,9 @@ spec:
             - "--upstream-url={{ $value.upstreamURL }}"
             - "--resources=uri=/*|groups={{ $value.oidc.groups }}"
             - "--scopes=groups"
+            - "--upstream-keepalive-timeout={{ $value.upstreamTimeout }}"
+            - "--upstream-timeout={{ $value.upstreamTimeout }}"
+            - "--upstream-response-header-timeout={{ $value.upstreamTimeout }}"
 {{- if $value.extraArgs }}
 {{ toYaml $value.extraArgs | indent 12 }}
 {{- end }}

--- a/kubesignin/values.yaml
+++ b/kubesignin/values.yaml
@@ -97,6 +97,7 @@ proxies:
     replicaCount: 2
     # Upstream service to proxy to
     upstreamURL: "https://k8s-dashboard-kubernetes-dashboard.kube-system.svc.cluster.local"
+    upstreamTimeout: "60s"
     oidc:
       # Ingress URL
       redirectURL: "kubernetes-dashboard.example.com"


### PR DESCRIPTION
The default `10s` timeout is too short for example with the Kubernetes dashboard and Kibana searches.

Related issue: https://github.com/skyscrapers/engineering/issues/70