### PR TITLE
Customize server read and write timeouts for keycloak-proxy

### DIFF
--- a/kubesignin/templates/proxy-deployment.yaml
+++ b/kubesignin/templates/proxy-deployment.yaml
@@ -35,6 +35,8 @@ spec:
             - "--upstream-keepalive-timeout={{ $value.upstreamTimeout }}"
             - "--upstream-timeout={{ $value.upstreamTimeout }}"
             - "--upstream-response-header-timeout={{ $value.upstreamTimeout }}"
+            - "--server-read-timeout={{ $value.upstreamTimeout }}"
+            - "--server-write-timeout={{ $value.upstreamTimeout }}"
 {{- if $value.extraArgs }}
 {{ toYaml $value.extraArgs | indent 12 }}
 {{- end }}


### PR DESCRIPTION
After more experimenting in https://github.com/teamleadercrm/skyscrapers/issues/168, it looks like we should also increase the server read and write timeouts.