### PR TITLE
Add Calico monitoring

### DIFF
--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   groups:
   - name: calico.rules
+    rules:
     - alert: CalicoNodeInstanceDown
       expr: up{job="{{ .Release.Name }}-calico"} != 1
       for: 5m

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: "{{ .Release.Name }}-calico"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: prometheus
+    prometheus: k8s-monitor
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  groups:
+  - name: calico.rules
+    - alert: CalicoNodeInstanceDown
+      expr: up{job="{{ .Release.Name }}-calico"} != 1
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: '{{`{{$labels.instance}}`}} of job {{`{{$labels.job}}`}} has been down for more than 5 minutes'
+        summary: 'Instance {{`{{$labels.instance}}`}} Pod: {{`{{$labels.pod}}`}} is down'
+    - alert: CalicoDataplaneFailures
+      expr: felix_int_dataplane_failures{job="{{ .Release.Name }}-calico"} > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: '{{`{{$labels.instance}}`}} with calico-node pod {{`{{$labels.pod}}`}} has been having dataplane failures'
+        summary: 'Instance {{`{{$labels.instance}}`}} - Dataplane failures'

--- a/cluster-monitoring/templates/service.yaml
+++ b/cluster-monitoring/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Release.Name }}-calico"
+  namespace: kube-system
+  labels:
+    app: "{{ .Release.Name }}-calico-node"
+    component: felix
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 9091
+    targetPort: 9091
+    protocol: TCP
+  selector:
+    k8s-app: calico-node

--- a/cluster-monitoring/templates/servicemonitor.yaml
+++ b/cluster-monitoring/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: "{{ .Release.Name }}-calico"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: prometheus
+    prometheus: k8s-monitor
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  endpoints:
+  - port: metrics
+    interval: 10s
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      app: "{{ .Release.Name }}-calico-node"
+      component: felix


### PR DESCRIPTION
Configures Prometheus to scrape calico metrics and defines some simple alerting rules.

Related issue: https://github.com/skyscrapers/engineering/issues/54
To be combined with the Grafana dashboard in https://github.com/skyscrapers/engineering/issues/54

Tested on our test cluster.