### PR TITLE
Implement a chart to deploy k8s-ec2-srcdst on infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ helm upgrade --install prometheus-operator coreos/prometheus-operator --namespac
 helm upgrade --install k8s-monitor skyscrapers/cluster-monitoring --namespace infrastructure --values helm-values.yaml
 helm upgrade --install fluentd-cloudwatch skyscrapers/fluentd-cloudwatch --namespace infrastructure --values helm-values-fluentd-cloudwatch.yaml
 helm upgrade --install kibana stable/kibana --namespace infrastructure --values helm-values-kibana.yaml
+# Deploys the latest version (to date) of the `k8s-ec2-srcdst` container. Can be removed once `kops` updates its deployed version: https://github.com/kubernetes/kops/pull/5746
 helm upgrade --install k8s-ec2-srcdst skyscrapers/k8s-ec2-srcdst --namespace infrastructure
 
 # Only when you use spot instances

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ helm upgrade --install kube-lego stable/kube-lego --namespace infrastructure --v
 helm upgrade --install nginx-ingress stable/nginx-ingress --namespace infrastructure --values helm-values-nginx-ingress.yaml
 helm upgrade --install external-dns stable/external-dns --namespace infrastructure --values helm-values.yaml --values helm-values-external-dns.yaml
 helm upgrade --install kubesignin skyscrapers/kubesignin --namespace infrastructure --values helm-values.yaml
-# TODO helm upgrade --install concourse-web skyscrapers/concourse --values values.yaml
 helm upgrade --install prometheus-operator coreos/prometheus-operator --namespace infrastructure --values helm-values.yaml --values helm-values-prometheus-operator.yaml
 helm upgrade --install k8s-monitor skyscrapers/cluster-monitoring --namespace infrastructure --values helm-values.yaml
 helm upgrade --install fluentd-cloudwatch skyscrapers/fluentd-cloudwatch --namespace infrastructure --values helm-values-fluentd-cloudwatch.yaml
 helm upgrade --install kibana stable/kibana --namespace infrastructure --values helm-values-kibana.yaml
+helm upgrade --install k8s-ec2-srcdst skyscrapers/k8s-ec2-srcdst --namespace infrastructure
 
 # Only when you use spot instances
 helm upgrade --install kube-spot-termination-notice-handler incubator/kube-spot-termination-notice-handler --namespace infrastructure --values helm-values-kube-spot-termination-notice-handler.yaml

--- a/k8s-ec2-srcdst/.helmignore
+++ b/k8s-ec2-srcdst/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/k8s-ec2-srcdst/Chart.yaml
+++ b/k8s-ec2-srcdst/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Deploys the k8s-ec2-srcdst container
+name: k8s-ec2-srcdst
+version: 0.1.0

--- a/k8s-ec2-srcdst/templates/_helpers.tpl
+++ b/k8s-ec2-srcdst/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-ec2-srcdst.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-ec2-srcdst.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-ec2-srcdst.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/k8s-ec2-srcdst/templates/deployment.yaml
+++ b/k8s-ec2-srcdst/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "k8s-ec2-srcdst.fullname" . }}
+  labels:
+    app: {{ include "k8s-ec2-srcdst.name" . }}
+    chart: {{ include "k8s-ec2-srcdst.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role.kubernetes.io/networking: "1"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "k8s-ec2-srcdst.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "k8s-ec2-srcdst.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      hostNetwork: true
+      serviceAccountName: {{ include "k8s-ec2-srcdst.fullname" . }}
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-certificates.crt"
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: AWS_REGION
+              value: {{ .Values.aws_region }}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              readOnly: true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/k8s-ec2-srcdst/templates/rbac.yaml
+++ b/k8s-ec2-srcdst/templates/rbac.yaml
@@ -1,0 +1,51 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "k8s-ec2-srcdst.fullname" . }}
+  labels:
+    app: {{ include "k8s-ec2-srcdst.name" . }}
+    chart: {{ include "k8s-ec2-srcdst.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "k8s-ec2-srcdst.fullname" . }}
+  labels:
+    app: {{ include "k8s-ec2-srcdst.name" . }}
+    chart: {{ include "k8s-ec2-srcdst.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role.kubernetes.io/networking: "1"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "k8s-ec2-srcdst.fullname" . }}
+  labels:
+    app: {{ include "k8s-ec2-srcdst.name" . }}
+    chart: {{ include "k8s-ec2-srcdst.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8s-ec2-srcdst.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "k8s-ec2-srcdst.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/k8s-ec2-srcdst/values.yaml
+++ b/k8s-ec2-srcdst/values.yaml
@@ -1,0 +1,31 @@
+# Default values for k8s-ec2-srcdst.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ottoyiu/k8s-ec2-srcdst
+  tag: v0.2.2
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+nodeSelector:
+  node-role.kubernetes.io/master: ""
+
+tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+  - key: CriticalAddonsOnly
+    operator: Exists
+
+affinity: {}
+
+aws_region: eu-west-1


### PR DESCRIPTION
This deploys the latest version (to date) of the [`k8s-ec2-srcdst`](https://github.com/ottoyiu/k8s-ec2-srcdst) container.

Based on the kops deployment: https://github.com/kubernetes/kops/blob/release-1.9/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template#L435

As per https://github.com/skyscrapers/engineering/issues/117