### PR TITLE
adding additional checks for CPU and memory

### DIFF
--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -56,7 +56,7 @@ spec:
         description: '{{`{{$labels.instance}}`}} is using more than 90% Memory for >1h '
         summary: 'Instance {{`{{$labels.instance}}`}} Memory usage high'
     - alert: CPUUsageHigh
-      expr: 100 * (1 - avg by(instance)(irate(node_cpu{mode='idle'}[1h]))) >= 10
+      expr: 100 * (1 - avg by(instance)(irate(node_cpu{mode='idle'}[1h]))) >= 90
       for: 5m
       labels:
         severity: warning

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    role: alert-rules
 spec:
   groups:
   - name: calico.rules
@@ -29,3 +30,36 @@ spec:
       annotations:
         description: '{{`{{$labels.instance}}`}} with calico-node pod {{`{{$labels.pod}}`}} has been having dataplane failures'
         summary: 'Instance {{`{{$labels.instance}}`}} - Dataplane failures'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: "{{ .Release.Name }}-node-custom"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: prometheus
+    prometheus: k8s-monitor
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "k8s-monitor"
+    heritage: "{{ .Release.Service }}"
+    role: alert-rules
+spec:
+  groups:
+  - name: node-custom.rules
+    rules:
+    - alert: MemoryUsageHigh
+      expr: (sum(node_memory_MemTotal) - sum(node_memory_MemFree + node_memory_Buffers + node_memory_Cached) ) / sum(node_memory_MemTotal) * 100 >= 90
+      for: 1h
+      labels:
+        severity: warning
+      annotations:
+        description: '{{`{{$labels.instance}}`}} is using more than 90% Memory for >1h '
+        summary: 'Instance {{`{{$labels.instance}}`}} Memory usage high'
+    - alert: CPUUsageHigh
+      expr: 100 * (1 - avg by(instance)(irate(node_cpu{mode='idle'}[1h]))) >= 10
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: '{{`{{$labels.instance}}`}} is using more than 90% CPU for >1h '
+        summary: 'Instance {{`{{$labels.instance}}`}} CPU usage high'

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -40,7 +40,7 @@ metadata:
     app: prometheus
     prometheus: k8s-monitor
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "k8s-monitor"
+    release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     role: alert-rules
 spec:

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -48,7 +48,7 @@ spec:
   - name: node-custom.rules
     rules:
     - alert: MemoryUsageHigh
-      expr: (sum(node_memory_MemTotal) - sum(node_memory_MemFree + node_memory_Buffers + node_memory_Cached) ) / sum(node_memory_MemTotal) * 100 >= 90
+      expr: ((node_memory_MemTotal - node_memory_MemFree - node_memory_Buffers - node_memory_Cached) / node_memory_MemTotal) * 100 >= 90
       for: 1h
       labels:
         severity: warning


### PR DESCRIPTION
Currently we don't have neither CPU nore Memory checks for k8s nodes.

This PR should rectify that by adding 2 new checks as per https://github.com/skyscrapers/engineering/issues/106. 
Medium priority