### PR TITLE
Add autoscaler svc monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ helm upgrade --install kube-lego stable/kube-lego --namespace infrastructure --v
 helm upgrade --install nginx-ingress stable/nginx-ingress --namespace infrastructure --values helm-values-nginx-ingress.yaml
 helm upgrade --install external-dns stable/external-dns --namespace infrastructure --values helm-values.yaml --values helm-values-external-dns.yaml
 helm upgrade --install kubesignin skyscrapers/kubesignin --namespace infrastructure --values helm-values.yaml
+helm upgrade --install k8s-autoscaler stable/cluster-autoscaler --namespace infrastructure --values helm-values-autoscaler.yaml
 helm upgrade --install prometheus-operator coreos/prometheus-operator --namespace infrastructure --values helm-values.yaml --values helm-values-prometheus-operator.yaml
 helm upgrade --install k8s-monitor skyscrapers/cluster-monitoring --namespace infrastructure --values helm-values.yaml
 helm upgrade --install fluentd-cloudwatch skyscrapers/fluentd-cloudwatch --namespace infrastructure --values helm-values-fluentd-cloudwatch.yaml

--- a/cluster-monitoring/templates/servicemonitor.yaml
+++ b/cluster-monitoring/templates/servicemonitor.yaml
@@ -20,3 +20,26 @@ spec:
     matchLabels:
       app: "{{ .Release.Name }}-calico-node"
       component: felix
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: "{{ .Release.Name }}-autoscaler"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: prometheus
+    prometheus: k8s-monitor
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  endpoints:
+  - port: http
+    interval: 10s
+  namespaceSelector:
+    matchNames:
+    - infrastructure
+  selector:
+    matchLabels:
+      app: aws-cluster-autoscaler
+      release: k8s-autoscaler


### PR DESCRIPTION
Adds the ServiceMonitor definition for https://github.com/skyscrapers/terraform-kubernetes/pull/92. See information in that PR.