### PR TITLE
changing helm patch to set affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"templat
 
 Now, due to a [bug in HELM/Kubelet](https://github.com/kubernetes/helm/issues/3121), we want to run the tiller on a separate node (make sure you've set `helm_node` to true in the [`cluster` terraform module](https://github.com/skyscrapers/terraform-kubernetes#cluster)).
 ```
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec": {"template": {"spec": {"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms":[{"matchExpressions": [{"key": "function","operator": "In","values": ["helm"]}]}]}}}}}}}'
+kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec": {"template": {"spec": {"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms":[{"matchExpressions": [{"key": "function","operator": "In","values": ["helm"]}]}]}}},"tolerations": [{"effect": "NoSchedule","key": "function","operator":"Equal","value": "helm"}]}}}}'
 ```
 
 This needs to be done once for every cluster we set up.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"templat
 
 Now, due to a [bug in HELM/Kubelet](https://github.com/kubernetes/helm/issues/3121), we want to run the tiller on a separate node (make sure you've set `helm_node` to true in the [`cluster` terraform module](https://github.com/skyscrapers/terraform-kubernetes#cluster)).
 ```
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"tolerations": [{"effect": "NoSchedule","key": "function","operator":"Equal","value": "helm"}]}}}}'
+kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec": {"template": {"spec": {"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms":[{"matchExpressions": [{"key": "function","operator": "In","values": ["helm"]}]}]}}}}}}}'
 ```
 
 This needs to be done once for every cluster we set up.


### PR DESCRIPTION
This change should add the command to assign the pod to the correct node. This should fix the error teamleader had where the tilller pod was running in the wrong node (probably same thing happened in qover). 
I followed this documentation and tested it in Teamleader
https://kubernetes.io/docs/concepts/configuration/assign-pod-node/