### PR TITLE
Change memory alert to check overcommitment

### DIFF
--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -47,14 +47,14 @@ spec:
   groups:
   - name: node-custom.rules
     rules:
-    - alert: MemoryUsageHigh
-      expr: ((node_memory_MemTotal - node_memory_MemFree - node_memory_Buffers - node_memory_Cached) / node_memory_MemTotal) * 100 >= 90
+    - alert: MemoryOvercommitted
+      expr: round(((sum(kube_pod_container_resource_limits_memory_bytes) by (node) / sum(kube_node_status_capacity_memory_bytes ) by (node) )) *100) >100
       for: 1h
       labels:
         severity: warning
       annotations:
-        description: '{{`{{$labels.instance}}`}} is using more than 90% Memory for >1h '
-        summary: 'Instance {{`{{$labels.instance}}`}} Memory usage high'
+        description: '{{`{{$labels.node}}`}} is overcommited by {{`{{$value}`}}%'
+        summary: 'Instance {{`{{$labels.node}}`}} Memory usage high'
     - alert: CPUUsageHigh
       expr: 100 * (1 - avg by(instance)(irate(node_cpu{mode='idle'}[1h]))) >= 90
       for: 5m

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -48,7 +48,7 @@ spec:
   - name: node-custom.rules
     rules:
     - alert: MemoryOvercommitted
-      expr: round(((sum(kube_pod_container_resource_limits_memory_bytes) by (node) / sum(kube_node_status_capacity_memory_bytes ) by (node) )) *100) >100
+      expr: round(((sum(kube_pod_container_resource_limits_memory_bytes) by (node) / sum(kube_node_status_capacity_memory_bytes ) by (node) )) *100) >=100
       for: 1h
       labels:
         severity: warning

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -53,7 +53,7 @@ spec:
       labels:
         severity: warning
       annotations:
-        description: '{{`{{$labels.node}}`}} is overcommited by {{`{{$value}`}}%'
+        description: '{{`{{$labels.node}}`}} is overcommited by {{`{{$value}}`}}'
         summary: 'Instance {{`{{$labels.node}}`}} Memory usage high'
     - alert: CPUUsageHigh
       expr: 100 * (1 - avg by(instance)(irate(node_cpu{mode='idle'}[1h]))) >= 90


### PR DESCRIPTION
For https://github.com/skyscrapers/engineering/issues/106
Change memory check to alert if nodes are overcommitted.

Alerts when total memory limits on a node is higher or equal to 100% of memory capacity.