### PR TITLE
Add default resource limits for some charts

### DIFF
--- a/k8s-ec2-srcdst/Chart.yaml
+++ b/k8s-ec2-srcdst/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys the k8s-ec2-srcdst container
 name: k8s-ec2-srcdst
-version: 0.1.0
+version: 0.1.1

--- a/k8s-ec2-srcdst/values.yaml
+++ b/k8s-ec2-srcdst/values.yaml
@@ -13,6 +13,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 resources:
+  limits:
+    cpu: 10m
+    memory: 64Mi
   requests:
     cpu: 10m
     memory: 64Mi

--- a/kubesignin/Chart.yaml
+++ b/kubesignin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Kubesignin chart for Kubernetes
 name: kubesignin
-version: 0.3.5
+version: 0.3.6
 keywords: [skyscrapers, kubesignin, dex, auth, oidc]
 home: https://github.com/skyscrapers/kubesignin.git
 maintainers:

--- a/kubesignin/values.yaml
+++ b/kubesignin/values.yaml
@@ -42,8 +42,8 @@ Dex:
   #   Username: "admin"
   #   UserID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 
-  Memory: "200Mi"
-  Cpu: "100m"
+  Memory: 28Mi
+  Cpu: 2m
   Replicas: 1
 
   LogLevel: info
@@ -62,8 +62,8 @@ Kubesignin:
   # # This is going to be used for both kubesignin and dex
   # DomainName: kubesignin.example.com
 
-  Memory: "200Mi"
-  Cpu: "100m"
+  Memory: 16Mi
+  Cpu: 2m
   Replicas: 1
 
   # Tokens that have these groups as claims will be given admin access to the cluster
@@ -85,11 +85,11 @@ proxy:
     externalPort: 3000
   resources:
     limits:
-      cpu: "20m"
-      memory: "50Mi"
+      cpu: 2m
+      memory: 16Mi
     requests:
-      cpu: "10m"
-      memory: "10Mi"
+      cpu: 1m
+      memory: 8Mi
 
 # Keycloack proxies to setup
 proxies:


### PR DESCRIPTION
As per https://github.com/skyscrapers/engineering/issues/142

## k8s-ec2-srcdst

- Max (and average) memory usage over 30 days has been 13 Mb
   - Previously there was a memory request of 64 Mi, set the same value for memory limit
- Max (and average) CPU usage over 30 days has been 6m
   - Previously there was a CPU request of 10m, set the same value for CPU limit

As requests = limits, its QoS will be guaranteed

## kubesignin-app

- Avg. memory usage over 30 days: 5.2Mi
   - Reduced memory request and limit from 200Mi to 16Mi
- Avg. CPU usage over 30 days: 0.1m
   - Reduced CPU request and limit from 100m to 2m

As requests = limits, its QoS will be guaranteed

## kubesignin-dex

- Avg. memory usage over 30 days: 10Mi
   - Reduced memory request and limit from 200Mi to 28Mi
- Avg. CPU usage over 30 days: 0.4m
   - Reduced CPU request and limit from 100m to 2m

As requests = limits, its QoS will be guaranteed

## all kubesignin proxies

- Avg. memory usage over 30 days: ~5Mi
   - Reduced memory request from 10Mi to 8Mi
   - Reduced memory limit from 50Mi to 16Mi
- Avg. CPU usage over 30 days: 0.1m
   - Reduced CPU request from 10m to 1m
   - Reduced CPU limit from 20m to 2m

As requests != limits, its QoS will be burstable