### PR TITLE
Add Concourse dashboards and small fixes

### DIFF
--- a/cluster-monitoring/README.md
+++ b/cluster-monitoring/README.md
@@ -97,3 +97,19 @@ kubectl delete crd alertmanagers.monitoring.coreos.com
 ```
 
 After the `helm purge` there might still be some leftover resources to delete. You can find these by running `kubectl get all --all-namespaces -l release=<your helm release name>` and delete those resources.
+
+## Acknowledgements
+
+### Grafana dashboard sources
+
+Included Grafana dashboards are based of the following sources:
+
+- [Elasticsearch](https://grafana.com/dashboards/4358)
+- [K8s Autoscaler](https://grafana.com/dashboards/3831)
+- [K8s Calico](https://grafana.com/dashboards/3244)
+- [K8s Nginx Ingress](https://grafana.com/dashboards/6927) with [certificate expiry](https://grafana.com/dashboards/6927)
+- [K8s Node Resource Requests](https://github.com/coreos/prometheus-operator/blob/master/helm/grafana/dashboards/kubernetes-resource-requests-dashboard.json)
+- [Concourse](https://github.com/bosh-prometheus/prometheus-boshrelease/tree/master/jobs/grafana_dashboards/templates)
+- [MongoDB](https://grafana.com/dashboards/2583)
+- [AWS SQS](https://grafana.com/dashboards/584)
+- [Webapp](https://grafana.com/dashboards/3816)

--- a/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-autoscaler.json
+++ b/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-autoscaler.json
@@ -1,6 +1,16 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn"   : 1,
+        "datasource": "-- Grafana --",
+        "enable"    : true,
+        "hide"      : true,
+        "iconColor" : "rgba(0, 211, 255, 1)",
+        "name"      : "Annotations & Alerts",
+        "type"      : "dashboard"
+      }
+    ]
   },
   "description" : "Super simple dashboard showing an overview of kubernetes cluster autoscaling activity and status, using metrics reported by the autoscaler to prometheus.\r\n\r\nhttps://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler",
   "editable"    : true,

--- a/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-calico.json
+++ b/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-calico.json
@@ -1,6 +1,16 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn"   : 1,
+        "datasource": "-- Grafana --",
+        "enable"    : true,
+        "hide"      : true,
+        "iconColor" : "rgba(0, 211, 255, 1)",
+        "name"      : "Annotations & Alerts",
+        "type"      : "dashboard"
+      }
+    ]
   },
   "description" : "Calico cluster monitoring dashboard",
   "editable"    : true,

--- a/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-nginx-ingress.json
+++ b/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-nginx-ingress.json
@@ -472,7 +472,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 9
       },
       "hideTimeOverride": false,
       "id"              : 75,
@@ -699,7 +699,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 15
+        "y": 3
       },
       "height": "200px",
       "id"    : 32,
@@ -815,7 +815,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 15
+        "y": 3
       },
       "id"    : 77,
       "isNew" : true,
@@ -917,7 +917,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 15
+        "y": 3
       },
       "height": "",
       "id"    : 79,
@@ -1007,6 +1007,86 @@
         "align"     : false,
         "alignLevel": null
       }
+    },
+    {
+      "columns": [
+        {
+          "text" : "Current",
+          "value": "current"
+        }
+      ],
+      "datasource": "Prometheus",
+      "fontSize"  : "100%",
+      "gridPos"   : {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "height"    : "1024",
+      "id"        : 85,
+      "links"     : [],
+      "pageSize"  : 7,
+      "scroll"    : true,
+      "showHeader": true,
+      "sort"      : {
+        "col" : 1,
+        "desc": false
+      },
+      "styles": [
+        {
+          "alias"     : "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern"   : "Time",
+          "type"      : "date"
+        },
+        {
+          "alias"    : "TTL",
+          "colorMode": "cell",
+          "colors"   : [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals"  : 0,
+          "pattern"   : "Current",
+          "thresholds": [
+            "0",
+            "691200"
+          ],
+          "type": "number",
+          "unit": "s"
+        },
+        {
+          "alias"    : "",
+          "colorMode": null,
+          "colors"   : [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals"  : 2,
+          "pattern"   : "/.*/",
+          "thresholds": [],
+          "type"      : "number",
+          "unit"      : "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr"          : "avg(nginx_ingress_controller_ssl_expire_time_seconds) by (host) - time()",
+          "format"        : "time_series",
+          "intervalFactor": 1,
+          "legendFormat"  : "{{ host }}",
+          "metric"        : "gke_letsencrypt_cert_expiration",
+          "refId"         : "A",
+          "step"          : 1
+        }
+      ],
+      "title"    : "Ingress Certificate Expiry",
+      "transform": "timeseries_aggregations",
+      "type"     : "table"
     }
   ],
   "refresh"      : "5s",

--- a/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-node-resource-requests.json
+++ b/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-node-resource-requests.json
@@ -393,7 +393,7 @@
     "k8s",
     "prometheus"
   ],
-  "templating"   : {
+  "templating": {
     "list": []
   },
   "time": {

--- a/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-resources-pod-v2.json
+++ b/cluster-monitoring/dashboards-default/grafana-dashboard-k8s-resources-pod-v2.json
@@ -348,7 +348,7 @@
     "k8s",
     "prometheus"
   ],
-  "templating"     : {
+  "templating": {
     "list": [
       {
         "allValue"      : ".*",

--- a/cluster-monitoring/dashboards-extra/grafana-dashboard-concourse-overview.json
+++ b/cluster-monitoring/dashboards-extra/grafana-dashboard-concourse-overview.json
@@ -1,0 +1,1088 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn"   : 1,
+        "datasource": "-- Grafana --",
+        "enable"    : true,
+        "hide"      : true,
+        "iconColor" : "rgba(0, 211, 255, 1)",
+        "name"      : "Annotations & Alerts",
+        "type"      : "dashboard"
+      }
+    ]
+  },
+  "editable"    : false,
+  "gnetId"      : null,
+  "graphTooltip": 0,
+  "id"          : null,
+  "iteration"   : 1523194747923,
+  "links"       : [
+    {
+      "asDropdown" : true,
+      "icon"       : "external link",
+      "includeVars": true,
+      "keepTime"   : true,
+      "tags"       : [
+        "concourse"
+      ],
+      "targetBlank": false,
+      "title"      : "Concourse",
+      "type"       : "dashboards"
+    },
+    {
+      "icon"       : "external link",
+      "tags"       : [],
+      "targetBlank": true,
+      "title"      : "Concourse Docs",
+      "tooltip"    : "",
+      "type"       : "link",
+      "url"        : "http://concourse.ci/metrics.html"
+    }
+  ],
+  "panels": [
+    {
+      "cacheTimeout"   : null,
+      "colorBackground": false,
+      "colorValue"     : false,
+      "colors"         : [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource" : "Prometheus",
+      "description": "Total number of Concourse builds started",
+      "format"     : "none",
+      "gauge"      : {
+        "maxValue"        : 100,
+        "minValue"        : 0,
+        "show"            : false,
+        "thresholdLabels" : false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id"          : 1,
+      "interval"    : null,
+      "links"       : [],
+      "mappingType" : 1,
+      "mappingTypes": [
+        {
+          "name" : "value to text",
+          "value": 1
+        },
+        {
+          "name" : "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints"  : 100,
+      "nullPointMode"  : "connected",
+      "nullText"       : null,
+      "postfix"        : "",
+      "postfixFontSize": "50%",
+      "prefix"         : "",
+      "prefixFontSize" : "50%",
+      "rangeMaps"      : [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to"  : "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full"     : false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show"     : true
+      },
+      "tableColumn": "",
+      "targets"    : [
+        {
+          "expr"          : "max(concourse_builds_started_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "refId"         : "A"
+        }
+      ],
+      "thresholds"   : "",
+      "title"        : "Builds Started",
+      "transparent"  : true,
+      "type"         : "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps"    : [
+        {
+          "op"   : "=",
+          "text" : "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout"   : null,
+      "colorBackground": false,
+      "colorValue"     : false,
+      "colors"         : [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource" : "Prometheus",
+      "description": "Total number of Concourse builds finished",
+      "format"     : "none",
+      "gauge"      : {
+        "maxValue"        : 100,
+        "minValue"        : 0,
+        "show"            : false,
+        "thresholdLabels" : false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id"          : 2,
+      "interval"    : null,
+      "links"       : [],
+      "mappingType" : 1,
+      "mappingTypes": [
+        {
+          "name" : "value to text",
+          "value": 1
+        },
+        {
+          "name" : "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints"  : 100,
+      "nullPointMode"  : "connected",
+      "nullText"       : null,
+      "postfix"        : "",
+      "postfixFontSize": "50%",
+      "prefix"         : "",
+      "prefixFontSize" : "50%",
+      "rangeMaps"      : [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to"  : "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full"     : false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show"     : true
+      },
+      "tableColumn": "",
+      "targets"    : [
+        {
+          "expr"          : "max(concourse_builds_finished_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "refId"         : "A"
+        }
+      ],
+      "thresholds"   : "",
+      "title"        : "Builds Finished",
+      "transparent"  : true,
+      "type"         : "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps"    : [
+        {
+          "op"   : "=",
+          "text" : "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout"   : null,
+      "colorBackground": false,
+      "colorValue"     : false,
+      "colors"         : [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource" : "Prometheus",
+      "description": "Total number of Concourse builds succeeded",
+      "format"     : "none",
+      "gauge"      : {
+        "maxValue"        : 100,
+        "minValue"        : 0,
+        "show"            : false,
+        "thresholdLabels" : false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id"          : 3,
+      "interval"    : null,
+      "links"       : [],
+      "mappingType" : 1,
+      "mappingTypes": [
+        {
+          "name" : "value to text",
+          "value": 1
+        },
+        {
+          "name" : "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints"  : 100,
+      "nullPointMode"  : "connected",
+      "nullText"       : null,
+      "postfix"        : "",
+      "postfixFontSize": "50%",
+      "prefix"         : "",
+      "prefixFontSize" : "50%",
+      "rangeMaps"      : [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to"  : "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full"     : false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show"     : true
+      },
+      "tableColumn": "",
+      "targets"    : [
+        {
+          "expr"          : "max(concourse_builds_succeeded_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "refId"         : "A"
+        }
+      ],
+      "thresholds"   : "",
+      "title"        : "Builds Succeeded",
+      "transparent"  : true,
+      "type"         : "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps"    : [
+        {
+          "op"   : "=",
+          "text" : "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout"   : null,
+      "colorBackground": false,
+      "colorValue"     : false,
+      "colors"         : [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource" : "Prometheus",
+      "description": "Total number of Concourse builds aborted",
+      "format"     : "none",
+      "gauge"      : {
+        "maxValue"        : 100,
+        "minValue"        : 0,
+        "show"            : false,
+        "thresholdLabels" : false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id"          : 4,
+      "interval"    : null,
+      "links"       : [],
+      "mappingType" : 1,
+      "mappingTypes": [
+        {
+          "name" : "value to text",
+          "value": 1
+        },
+        {
+          "name" : "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints"  : 100,
+      "nullPointMode"  : "connected",
+      "nullText"       : null,
+      "postfix"        : "",
+      "postfixFontSize": "50%",
+      "prefix"         : "",
+      "prefixFontSize" : "50%",
+      "rangeMaps"      : [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to"  : "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full"     : false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show"     : true
+      },
+      "tableColumn": "",
+      "targets"    : [
+        {
+          "expr"          : "max(concourse_builds_aborted_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "refId"         : "A"
+        }
+      ],
+      "thresholds"   : "",
+      "title"        : "Builds Aborted",
+      "transparent"  : true,
+      "type"         : "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps"    : [
+        {
+          "op"   : "=",
+          "text" : "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout"   : null,
+      "colorBackground": false,
+      "colorValue"     : false,
+      "colors"         : [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource" : "Prometheus",
+      "description": "Total number of Concourse builds errored",
+      "format"     : "none",
+      "gauge"      : {
+        "maxValue"        : 100,
+        "minValue"        : 0,
+        "show"            : false,
+        "thresholdLabels" : false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id"          : 5,
+      "interval"    : null,
+      "links"       : [],
+      "mappingType" : 1,
+      "mappingTypes": [
+        {
+          "name" : "value to text",
+          "value": 1
+        },
+        {
+          "name" : "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints"  : 100,
+      "nullPointMode"  : "connected",
+      "nullText"       : null,
+      "postfix"        : "",
+      "postfixFontSize": "50%",
+      "prefix"         : "",
+      "prefixFontSize" : "50%",
+      "rangeMaps"      : [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to"  : "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full"     : false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show"     : true
+      },
+      "tableColumn": "",
+      "targets"    : [
+        {
+          "expr"          : "max(concourse_builds_errored_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "refId"         : "A"
+        }
+      ],
+      "thresholds"   : "",
+      "title"        : "Builds Errored",
+      "transparent"  : true,
+      "type"         : "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps"    : [
+        {
+          "op"   : "=",
+          "text" : "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout"   : null,
+      "colorBackground": false,
+      "colorValue"     : false,
+      "colors"         : [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource" : "Prometheus",
+      "description": "Total number of Concourse builds failed",
+      "format"     : "none",
+      "gauge"      : {
+        "maxValue"        : 100,
+        "minValue"        : 0,
+        "show"            : false,
+        "thresholdLabels" : false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id"          : 6,
+      "interval"    : null,
+      "links"       : [],
+      "mappingType" : 1,
+      "mappingTypes": [
+        {
+          "name" : "value to text",
+          "value": 1
+        },
+        {
+          "name" : "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints"  : 100,
+      "nullPointMode"  : "connected",
+      "nullText"       : null,
+      "postfix"        : "",
+      "postfixFontSize": "50%",
+      "prefix"         : "",
+      "prefixFontSize" : "50%",
+      "rangeMaps"      : [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to"  : "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full"     : false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show"     : true
+      },
+      "tableColumn": "",
+      "targets"    : [
+        {
+          "expr"          : "max(concourse_builds_failed_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "refId"         : "A"
+        }
+      ],
+      "thresholds"   : "",
+      "title"        : "Builds Failed",
+      "transparent"  : true,
+      "type"         : "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps"    : [
+        {
+          "op"   : "=",
+          "text" : "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id"    : 7,
+      "legend": {
+        "avg"    : false,
+        "current": false,
+        "max"    : false,
+        "min"    : false,
+        "show"   : false,
+        "total"  : false,
+        "values" : false
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_builds_started_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "Started",
+          "refId"         : "A"
+        },
+        {
+          "expr"          : "max(concourse_builds_finished_total)",
+          "format"        : "time_series",
+          "instant"       : false,
+          "intervalFactor": 2,
+          "legendFormat"  : "Finished",
+          "refId"         : "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Builds Started / Finished",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "HTTP response duration",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id"    : 8,
+      "legend": {
+        "alignAsTable": true,
+        "avg"         : true,
+        "current"     : true,
+        "max"         : true,
+        "min"         : true,
+        "rightSide"   : true,
+        "show"        : true,
+        "sort"        : "current",
+        "sortDesc"    : false,
+        "total"       : false,
+        "values"      : true
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "avg(rate(concourse_http_responses_duration_seconds_sum[5m]) / rate(concourse_http_responses_duration_seconds_count[5m]))",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "{{ route }}",
+          "refId"         : "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "HTTP Response Duration",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "s",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Number of containers per worker",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id"    : 9,
+      "legend": {
+        "avg"    : false,
+        "current": false,
+        "max"    : false,
+        "min"    : false,
+        "show"   : false,
+        "total"  : false,
+        "values" : false
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_workers_containers) by(worker)",
+          "format"        : "time_series",
+          "interval"      : "",
+          "intervalFactor": 2,
+          "legendFormat"  : "{{ worker }}",
+          "refId"         : "A",
+          "step"          : 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Worker Containers",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Number of volumes per worker",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id"    : 10,
+      "legend": {
+        "avg"    : false,
+        "current": false,
+        "max"    : false,
+        "min"    : false,
+        "show"   : false,
+        "total"  : false,
+        "values" : false
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_workers_volumes) by(worker)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "{{ worker }}",
+          "refId"         : "A",
+          "step"          : 60
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Worker Volumes",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Current number of concourse database connections",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id"    : 11,
+      "legend": {
+        "alignAsTable": false,
+        "avg"         : false,
+        "current"     : false,
+        "max"         : false,
+        "min"         : false,
+        "rightSide"   : false,
+        "show"        : false,
+        "total"       : false,
+        "values"      : false
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_db_connections) by(dbname)",
+          "format"        : "time_series",
+          "interval"      : "",
+          "intervalFactor": 2,
+          "legendFormat"  : "{{ dbname }}",
+          "refId"         : "A",
+          "step"          : 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Database Connections",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Recent number of Concourse database queries",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id"    : 12,
+      "legend": {
+        "avg"    : false,
+        "current": false,
+        "max"    : false,
+        "min"    : false,
+        "show"   : false,
+        "total"  : false,
+        "values" : false
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_db_queries_total)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "Queries",
+          "refId"         : "A",
+          "step"          : 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Database Queries",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    }
+  ],
+  "refresh"      : "30s",
+  "schemaVersion": 16,
+  "style"        : "dark",
+  "tags"         : [
+    "concourse",
+    "prometheus"
+  ],
+  "time": {
+    "from": "now-1h",
+    "to"  : "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title"   : "Concourse / Overview",
+  "uid"     : "concourse_overview",
+  "version" : 1
+}

--- a/cluster-monitoring/dashboards-extra/grafana-dashboard-concourse-pipelines.json
+++ b/cluster-monitoring/dashboards-extra/grafana-dashboard-concourse-pipelines.json
@@ -1,0 +1,441 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn"   : 1,
+        "datasource": "-- Grafana --",
+        "enable"    : true,
+        "hide"      : true,
+        "iconColor" : "rgba(0, 211, 255, 1)",
+        "name"      : "Annotations & Alerts",
+        "type"      : "dashboard"
+      }
+    ]
+  },
+  "editable"    : false,
+  "gnetId"      : null,
+  "graphTooltip": 0,
+  "id"          : null,
+  "iteration"   : 1523181477375,
+  "links"       : [
+    {
+      "asDropdown" : true,
+      "icon"       : "external link",
+      "includeVars": true,
+      "keepTime"   : true,
+      "tags"       : [
+        "concourse"
+      ],
+      "targetBlank": false,
+      "title"      : "Concourse",
+      "type"       : "dashboards"
+    },
+    {
+      "icon"       : "external link",
+      "tags"       : [],
+      "targetBlank": true,
+      "title"      : "Concourse Docs",
+      "type"       : "link",
+      "url"        : "http://concourse.ci/metrics.html"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Last time taken to schedule an entire pipeline",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id"    : 1,
+      "legend": {
+        "avg"    : false,
+        "current": false,
+        "max"    : false,
+        "min"    : false,
+        "show"   : false,
+        "total"  : false,
+        "values" : false
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_scheduling_full_duration_seconds_total{pipeline=~\"$pipeline\"}) by(pipeline)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "Duration",
+          "refId"         : "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Scheduling: Full",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "s",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Last time taken to load version information from the database for a pipeline",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id"    : 2,
+      "legend": {
+        "avg"    : false,
+        "current": false,
+        "max"    : false,
+        "min"    : false,
+        "show"   : false,
+        "total"  : false,
+        "values" : false
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_scheduling_loading_duration_seconds_total{pipeline=~\"$pipeline\"}) by(pipeline)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "Duration",
+          "refId"         : "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Scheduling: Loading",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "s",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Count of builds finished",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id"    : 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg"         : false,
+        "current"     : true,
+        "max"         : false,
+        "min"         : false,
+        "rightSide"   : true,
+        "show"        : true,
+        "total"       : false,
+        "values"      : true
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "max(concourse_builds_finished{pipeline=~\"$pipeline\"}) by(pipeline, status)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "{{ status }}",
+          "refId"         : "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Builds Finished",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format"  : "short",
+          "label"   : null,
+          "logBase" : 1,
+          "max"     : null,
+          "min"     : "0",
+          "show"    : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars"       : false,
+      "dashLength" : 10,
+      "dashes"     : false,
+      "datasource" : "Prometheus",
+      "description": "Build time",
+      "fill"       : 1,
+      "gridPos"    : {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id"    : 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg"         : true,
+        "current"     : true,
+        "max"         : true,
+        "min"         : true,
+        "rightSide"   : true,
+        "show"        : true,
+        "total"       : false,
+        "values"      : true
+      },
+      "lines"          : true,
+      "linewidth"      : 1,
+      "links"          : [],
+      "nullPointMode"  : "null",
+      "percentage"     : false,
+      "pointradius"    : 5,
+      "points"         : false,
+      "renderer"       : "flot",
+      "seriesOverrides": [],
+      "spaceLength"    : 10,
+      "stack"          : false,
+      "steppedLine"    : false,
+      "targets"        : [
+        {
+          "expr"          : "avg(rate(concourse_builds_duration_seconds_sum{pipeline=~\"$pipeline\"}[5m]) / rate(concourse_builds_duration_seconds_count{pipeline=~\"$pipeline\"}[5m])) by(pipeline)",
+          "format"        : "time_series",
+          "intervalFactor": 2,
+          "legendFormat"  : "Duration",
+          "refId"         : "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom"  : null,
+      "timeShift" : null,
+      "title"     : "Build Duration",
+      "tooltip"   : {
+        "shared"    : true,
+        "sort"      : 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type"       : "graph",
+      "xaxis"      : {
+        "buckets": null,
+        "mode"   : "time",
+        "name"   : null,
+        "show"   : true,
+        "values" : []
+      },
+      "yaxes": [
+        {
+          "format" : "s",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : "0",
+          "show"   : true
+        },
+        {
+          "format" : "short",
+          "label"  : null,
+          "logBase": 1,
+          "max"    : null,
+          "min"    : null,
+          "show"   : false
+        }
+      ]
+    }
+  ],
+  "refresh"      : "30s",
+  "schemaVersion": 16,
+  "style"        : "dark",
+  "tags"         : [
+    "concourse",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue"      : null,
+        "current"       : {},
+        "datasource"    : "Prometheus",
+        "hide"          : 0,
+        "includeAll"    : false,
+        "label"         : "Pipeline",
+        "multi"         : false,
+        "name"          : "pipeline",
+        "options"       : [],
+        "query"         : "label_values(concourse_builds_finished, pipeline)",
+        "refresh"       : 1,
+        "regex"         : "",
+        "sort"          : 1,
+        "tagValuesQuery": "",
+        "tags"          : [],
+        "tagsQuery"     : "",
+        "type"          : "query",
+        "useTags"       : false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to"  : "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title"   : "Concourse / Pipelines",
+  "uid"     : "concourse_pipelines",
+  "version" : 1
+}

--- a/cluster-monitoring/dashboards-extra/grafana-dashboard-mongodb.json
+++ b/cluster-monitoring/dashboards-extra/grafana-dashboard-mongodb.json
@@ -1,6 +1,16 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn"   : 1,
+        "datasource": "-- Grafana --",
+        "enable"    : true,
+        "hide"      : true,
+        "iconColor" : "rgba(0, 211, 255, 1)",
+        "name"      : "Annotations & Alerts",
+        "type"      : "dashboard"
+      }
+    ]
   },
   "editable"    : true,
   "gnetId"      : 2583,

--- a/cluster-monitoring/dashboards-extra/grafana-dashboard-sqs.json
+++ b/cluster-monitoring/dashboards-extra/grafana-dashboard-sqs.json
@@ -476,7 +476,7 @@
     "sqs",
     "prometheus"
   ],
-  "templating"   : {
+  "templating": {
     "list": [
       {
         "allValue"      : null,


### PR DESCRIPTION
Cluster-monitoring improvements:
- Add dashboards for Concourse
- Add certificate expiry for Nginx Ingress
- Add source dashboards to README

Related issues: https://github.com/skyscrapers/engineering/issues/143 and https://github.com/skyscrapers/engineering/issues/39

![image](https://user-images.githubusercontent.com/33081/48907191-081d9a00-ee67-11e8-93db-da10164049ee.png)
![image](https://user-images.githubusercontent.com/33081/48907215-153a8900-ee67-11e8-91cf-b7e8f9595830.png)
