### PR TITLE
Cronjobs monitoring for non succeeded jobs

### DIFF
--- a/cronjobs-monitoring/.helmignore
+++ b/cronjobs-monitoring/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/cronjobs-monitoring/Chart.yaml
+++ b/cronjobs-monitoring/Chart.yaml
@@ -1,0 +1,17 @@
+name: cronjobs-monitoring
+version: 0.1.2
+description: Cloudwatch monitoring using Prometheus-operator and Grafana.
+keywords:
+  - kube-state-metrics
+  - monitoring
+  - prometheus
+  - cronjobs
+home: https://github.com/skyscrapers/charts/
+sources:
+  - https://github.com/coreos/prometheus-operator
+  - https://github.com/helm/charts/tree/master/stable/prometheus-operator
+  - https://github.com/skyscrapers/charts
+maintainers:
+  - name: skyscrapers
+    email: hello@skyscrapers.eu
+engine: gotpl

--- a/cronjobs-monitoring/Chart.yaml
+++ b/cronjobs-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: cronjobs-monitoring
-version: 0.1.2
+version: 0.0.1
 description: Cloudwatch monitoring using Prometheus-operator and Grafana.
 keywords:
   - kube-state-metrics

--- a/cronjobs-monitoring/README.md
+++ b/cronjobs-monitoring/README.md
@@ -1,0 +1,25 @@
+# cronjobs-monitoring
+
+A Helm chart for monitoring cronjobs status via Prometheus and AlertManager. This chart  configures Prometheus (via the [Operator](https://github.com/coreos/prometheus-operator)) for using the metrics from [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics), sets up an alert for when a job does not succeed.
+
+## TL;DR
+
+```shell
+helm install skyscrapers/cronjobs-monitoring -f values.yaml
+```
+
+The command deploys the Prometheus rules of cronjobs monitoring setup on the cluster in the default configuration.
+
+> **Tip**: List all releases using `helm list`
+
+**Note**: You should deploy this chart in the same namespace as your Prometheus for the configuration to be automatically picked up.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```shell
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/cronjobs-monitoring/requirements.yaml
+++ b/cronjobs-monitoring/requirements.yaml
@@ -1,0 +1,4 @@
+# dependencies:
+# - name: prometheus-operator
+#   version: 0.1.21
+#   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/cronjobs-monitoring/templates/_helpers.tpl
+++ b/cronjobs-monitoring/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cronjobs-monitoring.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cronjobs-monitoring.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "labels" }}
+app: {{ template "cronjobs-monitoring.fullname" . }}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+release: {{ .Release.Name | quote }}
+heritage: {{ .Release.Service | quote }}
+{{- end }}

--- a/cronjobs-monitoring/templates/prometheusrule.yaml
+++ b/cronjobs-monitoring/templates/prometheusrule.yaml
@@ -1,0 +1,54 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+{{ include "labels" $ | indent 4 }}
+    {{- range $key, $val := .Values.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end}}
+  name: "{{ .Release.Name }}"
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  groups:
+  - name: cronjobs.rules
+    rules:
+    - record: job_cronjob:kube_job_status_start_time:max                                                            
+      expr: |
+        label_replace(
+          label_replace(
+            max(
+              kube_job_status_start_time
+              * ON(exported_job) GROUP_RIGHT()
+              kube_job_labels{label_cronjob!=""}
+            ) BY (exported_job, label_cronjob)
+            == ON(label_cronjob) GROUP_LEFT()
+            max(
+              kube_job_status_start_time
+              * ON(exported_job) GROUP_RIGHT()
+              kube_job_labels{label_cronjob!=""}
+            ) BY (label_cronjob),
+            "job", "$1", "exported_job", "(.+)"),
+          "cronjob", "$1", "label_cronjob", "(.+)")
+    - record: job_cronjob:kube_job_status_succeeded:sum
+        expr: |
+          clamp_max(
+            job_cronjob:kube_job_status_start_time:max,
+          1)
+          * ON(job) GROUP_LEFT()
+          label_replace(
+            label_replace(
+              (kube_job_status_succeeded = 0),
+              "job", "$1", "exported_job", "(.+)"),
+            "cronjob", "$1", "label_cronjob", "(.+)")
+    - alert: CronJobStatusFailed
+        expr: |
+          job_cronjob:kube_job_status_succeeded:sum
+          * ON(cronjob) GROUP_RIGHT()
+          kube_cronjob_labels
+          > 0
+        for: 1m
+        labels:
+          severity: critical
+          group: cronjobs
+        annotations:
+          description: '{{ $labels.cronjob }} last run did not succeed {{ $value }} times.'

--- a/cronjobs-monitoring/templates/prometheusrule.yaml
+++ b/cronjobs-monitoring/templates/prometheusrule.yaml
@@ -18,37 +18,36 @@ spec:
           label_replace(
             max(
               kube_job_status_start_time
-              * ON(exported_job) GROUP_RIGHT()
+              * ON(job_name) GROUP_RIGHT()
               kube_job_labels{label_cronjob!=""}
-            ) BY (exported_job, label_cronjob)
+            ) BY (job_name, label_cronjob)
             == ON(label_cronjob) GROUP_LEFT()
             max(
               kube_job_status_start_time
-              * ON(exported_job) GROUP_RIGHT()
+              * ON(job_name) GROUP_RIGHT()
               kube_job_labels{label_cronjob!=""}
             ) BY (label_cronjob),
-            "job", "$1", "exported_job", "(.+)"),
+            "job", "$1", "job_name", "(.+)"),
           "cronjob", "$1", "label_cronjob", "(.+)")
-    - record: job_cronjob:kube_job_status_succeeded:sum
-        expr: |
-          clamp_max(
-            job_cronjob:kube_job_status_start_time:max,
-          1)
-          * ON(job) GROUP_LEFT()
+    - record: job_cronjob:kube_job_status_not_succeed:sum
+      expr: |
+        clamp_max(
+          job_cronjob:kube_job_status_start_time:max,
+        1)
+        * ON(job) GROUP_LEFT()
+        label_replace(
           label_replace(
-            label_replace(
-              (kube_job_status_succeeded = 0),
-              "job", "$1", "exported_job", "(.+)"),
-            "cronjob", "$1", "label_cronjob", "(.+)")
-    - alert: CronJobStatusFailed
-        expr: |
-          job_cronjob:kube_job_status_succeeded:sum
-          * ON(cronjob) GROUP_RIGHT()
-          kube_cronjob_labels
-          > 0
-        for: 1m
-        labels:
-          severity: critical
-          group: cronjobs
-        annotations:
-          description: '{{ $labels.cronjob }} last run did not succeed {{ $value }} times.'
+            (kube_job_status_succeeded == 0),
+            "job", "$1", "job_name", "(.+)"),
+          "cronjob", "$1", "label_cronjob", "(.+)")
+    - alert: CronJobFailures
+      expr: |
+        job_cronjob:kube_job_status_not_succeed:sum
+        == 0
+      for: 1m
+      labels:
+        severity: critical
+        group: cronjobs
+      annotations:
+        description: '{{ `{{ $labels.cronjob }}` }} last run did not succeed.'
+

--- a/cronjobs-monitoring/values.yaml
+++ b/cronjobs-monitoring/values.yaml
@@ -1,0 +1,3 @@
+## Prometheus MatchLabel selectors
+labels:
+  prometheus: "application-monitor"


### PR DESCRIPTION
Sometimes a cronjob may fail or not run a pod at all and it just exit silently and show a status of:
```
Pods:
0 active  0 succeeded  0 failed
```

This is to get an alert when it happens for any cron job that has a label with the name: `cronjob` 
