### PR TITLE
filter jobs by namespace for cronjob monitoring

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: cluster-monitoring
-version: 1.1.1
+version: 1.1.2
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -75,13 +75,13 @@ spec:
           label_replace(
             max(
               kube_job_status_start_time
-              * ON(job_name) GROUP_RIGHT()
+              * ON(job_name, namespace) GROUP_RIGHT()
               kube_job_labels{label_cronjob!=""}
-            ) BY (job_name, label_cronjob)
+            ) BY (job_name, namespace, label_cronjob)
             == ON(label_cronjob) GROUP_LEFT()
             max(
               kube_job_status_start_time
-              * ON(job_name) GROUP_RIGHT()
+              * ON(job_name, namespace) GROUP_RIGHT()
               kube_job_labels{label_cronjob!=""}
             ) BY (label_cronjob),
             "job", "$1", "job_name", "(.+)"),


### PR DESCRIPTION
Add `namespace` filtering as having two jobs with the same name in two different namespaces breaks the one-to-many matching

Query is tested in Prometheus web UI with the mentioned test case