### PR TITLE
Add a runbook_url to all custom alerts and clarify some of them.

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: cluster-monitoring
-version: 1.1.2
+version: 1.1.3
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -19,6 +19,7 @@ spec:
       annotations:
         description: '{{`{{$labels.instance}}`}} of job {{`{{$labels.job}}`}} has been down for more than 5 minutes'
         summary: 'Instance {{`{{$labels.instance}}`}} Pod: {{`{{$labels.pod}}`}} is down'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-caliconodeinstancedown'
     - alert: CalicoDataplaneFailures
       expr: felix_int_dataplane_failures{job="{{ .Release.Name }}-calico"} > 0
       for: 5m
@@ -27,6 +28,7 @@ spec:
       annotations:
         description: '{{`{{$labels.instance}}`}} with calico-node pod {{`{{$labels.pod}}`}} has been having dataplane failures'
         summary: 'Instance {{`{{$labels.instance}}`}} - Dataplane failures'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-calicodataplanefailures'
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -48,6 +50,7 @@ spec:
       annotations:
         description: '{{`{{$labels.node}}`}} is overcommited by {{`{{$value}}`}}%'
         summary: 'Instance {{`{{$labels.node}}`}} Memory usage high'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-memoryovercommitted'
     - alert: CPUUsageHigh
       expr: 100 * (1 - avg by(instance)(irate(node_cpu{mode='idle'}[1h]))) >= 90
       for: 5m
@@ -56,6 +59,7 @@ spec:
       annotations:
         description: '{{`{{$labels.instance}}`}} is using more than 90% CPU for >1h '
         summary: 'Instance {{`{{$labels.instance}}`}} CPU usage high'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-cpuusagehigh'
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch-monitoring
-version: 0.2.1
+version: 0.2.2
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/elasticsearch-monitoring/templates/prometheusrule.yaml
+++ b/elasticsearch-monitoring/templates/prometheusrule.yaml
@@ -69,26 +69,26 @@ spec:
   - name: esdata.rules
     rules:
     {{- if .Values.amazonService.enabled }}
-    - alert: ElasticsearchLowDiskSpace
+    - alert: ElasticsearchAWSLowDiskSpace
       expr: aws_es_free_storage_space_minimum{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} <= 10240
       for: 15m
       labels:
         severity: warning
         group: persistence
       annotations:
-        description: 'Elasticsearch cluster {{`{{ $labels.domain_namae }}`}} has less than 10GB left'
-        summary: Elasticsearch low disk
-        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchlowdiskspace'
-    - alert: ElasticsearchNoDiskSpace
+        description: 'AWS Elasticsearch cluster {{`{{ $labels.domain_namae }}`}} has less than 10GB left'
+        summary: AWS Elasticsearch low disk
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchawslowdiskspace'
+    - alert: ElasticsearchAWSNoDiskSpace
       expr: aws_es_free_storage_space_minimum{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} <= 5120
       for: 15m
       labels:
         severity: critical
         group: persistence
       annotations:
-        description: 'Elasticsearch cluster {{`{{ $labels.domain_name }}`}} has less than 5GB left'
-        summary: Elasticsearch out of disk
-        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchnodiskspace'
+        description: 'AWS Elasticsearch cluster {{`{{ $labels.domain_name }}`}} has less than 5GB left'
+        summary: AWS Elasticsearch out of disk
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchawsnodiskspace'
     {{- else }}
     - alert: ElasticsearchLowDiskSpace
       expr: elasticsearch_filesystem_data_available_bytes{job="{{ .Release.Name }}-elasticsearch-exporter"} / elasticsearch_filesystem_data_size_bytes{job="{{ .Release.Name }}-elasticsearch-exporter"} <= 0.1

--- a/elasticsearch-monitoring/templates/prometheusrule.yaml
+++ b/elasticsearch-monitoring/templates/prometheusrule.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         description: 'The Elasticsearch metrics exporter for {{`{{ $labels.job }}`}} is down!'
         summary: Elasticsearch monitoring is DOWN!
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchexporterdown'
     {{- if .Values.amazonService.enabled }}
     - alert: ElasticsearchCloudwatchExporterDown
       expr: up{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} != 1
@@ -31,6 +32,7 @@ spec:
       annotations:
         description: 'The Elasticsearch Cloudwatch metrics exporter for {{`{{ $labels.job }}`}} is down!'
         summary: Elasticsearch monitoring is DOWN!
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchcloudwatchexporterdown'
     {{- end }}
   - name: escluster.rules
     rules:
@@ -43,6 +45,7 @@ spec:
       annotations:
         description: 'Elasticsearch cluster health for {{`{{ $labels.cluster }}`}} is yellow.'
         summary: Elasticsearch cluster is Yellow
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchclusterhealthyellow'
     - alert: ElasticsearchClusterHealthRed
       expr: elasticsearch_cluster_health_status{color="red", job="{{ .Release.Name }}-elasticsearch-exporter"} != 0
       for: 5m
@@ -52,6 +55,7 @@ spec:
       annotations:
         description: 'Elasticsearch cluster health for {{`{{ $labels.cluster }}`}} is RED!'
         summary: Elasticsearch cluster is RED!
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchclusterhealthred'
     - alert: ElasticsearchClusterEndpointDown
       expr: elasticsearch_cluster_health_up{job="{{ .Release.Name }}-elasticsearch-exporter"} != 1
       for: 5m
@@ -61,6 +65,7 @@ spec:
       annotations:
         description: 'Elasticsearch cluster endpoint for {{`{{ $labels.cluster }}`}} is DOWN!'
         summary: Elasticsearch cluster endpoint is DOWN!
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchclusterendpointdown'
   - name: esdata.rules
     rules:
     {{- if .Values.amazonService.enabled }}
@@ -73,6 +78,7 @@ spec:
       annotations:
         description: 'Elasticsearch cluster {{`{{ $labels.domain_namae }}`}} has less than 10GB left'
         summary: Elasticsearch low disk
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchlowdiskspace'
     - alert: ElasticsearchNoDiskSpace
       expr: aws_es_free_storage_space_minimum{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} <= 5120
       for: 15m
@@ -82,6 +88,7 @@ spec:
       annotations:
         description: 'Elasticsearch cluster {{`{{ $labels.domain_name }}`}} has less than 5GB left'
         summary: Elasticsearch out of disk
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchnodiskspace'
     {{- else }}
     - alert: ElasticsearchLowDiskSpace
       expr: elasticsearch_filesystem_data_available_bytes{job="{{ .Release.Name }}-elasticsearch-exporter"} / elasticsearch_filesystem_data_size_bytes{job="{{ .Release.Name }}-elasticsearch-exporter"} <= 0.1
@@ -92,6 +99,7 @@ spec:
       annotations:
         description: 'Elasticsearch node {{`{{ $labels.node }}`}} on cluster {{`{{ $labels.cluster }}`}} is low on free disk space'
         summary: Elasticsearch low disk
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchlowdiskspace'
     - alert: ElasticsearchNoDiskSpace
       expr: elasticsearch_filesystem_data_available_bytes{job="{{ .Release.Name }}-elasticsearch-exporter"} / elasticsearch_filesystem_data_size_bytes{job="{{ .Release.Name }}-elasticsearch-exporter"} <= 0.05
       for: 15m
@@ -101,6 +109,7 @@ spec:
       annotations:
         description: 'Elasticsearch node {{`{{ $labels.node }}`}} on cluster {{`{{ $labels.cluster }}`}} has no free disk space'
         summary: Elasticsearch out of disk
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchnodiskspace'
     {{- end }}
   - name: esmemory.rules
     rules:
@@ -113,3 +122,4 @@ spec:
       annotations:
         description: 'The JVM heap usage for Elasticsearch cluster {{`{{ $labels.cluster }}`}} on node {{`{{ $labels.node }}`}} has been over 90% for 15m'
         summary: ElasticSearch heap usage is high
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchheaptoohigh'

--- a/mongodb-monitoring/Chart.yaml
+++ b/mongodb-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-monitoring
-version: 1.0.0
+version: 1.0.1
 description: MongoDB monitoring using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/mongodb-monitoring/templates/prometheusrule.yaml
+++ b/mongodb-monitoring/templates/prometheusrule.yaml
@@ -16,34 +16,48 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: persistence
+      annotations:
+        description: 'The MongoDB metrics exporter for {{`{{ $labels.job }}`}} is down!'
+        summary: MongoDB monitoring is DOWN!
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-mongodbmetricsdown'
     - alert: MongodbNoConnectionsAvailable
       expr: mongodb_mongod_connections{state='available'} == 0
       for: 5m
       labels:
         severity: warning
+        group: persistence
       annotations:
         description: 'No connections available anymore on {{`{{$labels.instance}}`}}'
         summary: 'No connections available anymore on {{`{{$labels.instance}}`}}'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-mongodbnoconnectionsavailable'
     - alert: MongodbUnhealthyMember
       expr: mongodb_mongod_replset_member_health != 1
       for: 1m
       labels:
         severity: critical
+        group: persistence
       annotations:
         description: 'A mongo node with issues has been detected on {{`{{$labels.instance}}`}}'
         summary: 'A mongo node in the cluster is unhealthy'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-mongodbunhealthymember'
     - alert: MongodbReplicationLagWarning
       expr: rate(mongodb_mongod_replset_oplog_head_timestamp[5m]) > 10
       for: 5m
       labels:
         severity: warning
+        group: persistence
       annotations:
         description: 'The replication is running out on {{`{{$labels.instance}}`}} more than 10 seconds'
-        summary:  'The replication is lagging on {{`{{$labels.instance}}`}}'
+        summary: 'The replication is lagging on {{`{{$labels.instance}}`}}'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-mongodbreplicationlagwarning'
     - alert: MongodbReplicationLagCritical
       expr: rate(mongodb_mongod_replset_oplog_head_timestamp[5m]) > 60
       for: 5m
       labels:
         severity: critical
+        group: persistence
+      annotations:
         description: 'The replication is running out on {{`{{$labels.instance}}`}} more than 60 seconds'
-        summary:  'The replication is lagging on {{`{{$labels.instance}}`}}'
+        summary: 'The replication is lagging on {{`{{$labels.instance}}`}}'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-mongodbreplicationlagcritical'


### PR DESCRIPTION
Add a `runbook_url` annotation to our custom alerts, pointing to our documentation repo (https://github.com/skyscrapers/documentation/pull/22).

I've also clarified some alert descriptions and added the `group: peristence` label on the mongodb alerts.