### PR TITLE
Increase ES exporter scrape interval and timeout

### DIFF
--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch-monitoring
-version: 0.2.2
+version: 0.2.3
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/elasticsearch-monitoring/README.md
+++ b/elasticsearch-monitoring/README.md
@@ -48,7 +48,8 @@ Parameter | Description | Default
 `prometheus.app` | Sets the `app` label value (ServiceMonitor & Alerting rules) | `prometheus`
 `prometheus.name` | Sets the `prometheus` label value (ServiceMonitor & Alerting rules) | `k8s-monitor`
 `prometheus.role` | Sets the `role` label value (Alerting rules) | `alert-rules`
-`interval` | Interval for how often Prometheus scrapes the elasticsearch-exporter | `30s`
+`esExporterScrapeInterval` | Interval for how often Prometheus scrapes the elasticsearch-exporter | `60s`
+`esExporterScrapeTimeout` | Tiemout for the elasticsearch-exporter Prometheus scraper | `30s`
 `amazonService.enabled` | Whether we're monitoring an Amazon Elasticsearch Service domain. Enabling this will get disk statistics from Cloudwatch instead of Elasticsearch directly | `false`
 `amazonService.interval` | Interval for how often Prometheus scrapes the prometheus-cloudwatch-exporter | `600s`
 

--- a/elasticsearch-monitoring/templates/servicemonitor.yaml
+++ b/elasticsearch-monitoring/templates/servicemonitor.yaml
@@ -10,7 +10,8 @@ metadata:
     {{- end}}
 spec:
   endpoints:
-  - interval: {{ .Values.interval }}
+  - interval: {{ .Values.esExporterScrapeInterval }}
+    scrapeTimeout: {{ .Values.esExporterScrapeTimeout }}
     port: http
   namespaceSelector:
     matchNames:

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -4,7 +4,8 @@ prometheus:
     prometheus: "k8s-monitor"
 
 ## Interval for how often Prometheus scrapes the elasticsearch-exporter
-interval: "30s"
+esExporterScrapeInterval: "60s"
+esExporterScrapeTimeout: "30s"
 
 ## Whether we're monitoring an Amazon Elasticsearch Service domain.
 ## Enabling this will get disk statistics from Cloudwatch instead of


### PR DESCRIPTION

This sets the default elasticsearch-exporter scrape target interval to 60 seconds and the timeout to 30 seconds.
Both values are configurable.

10 seconds for the scrape timeout seemed to be insufficient in some large ES clusters, where the ES endpoint took longer to respond.

Also, according to the es exporter documentation (https://github.com/justwatchcom/elasticsearch_exporter#configuration) having a short scrape interval can impose load on the ES cluster, so I've increased the interval to a still-reasonable 60 seconds.

As per https://github.com/skyscrapers/engineering/issues/217