### PR TITLE
Tune the AWS ES storage space alerts

### DIFF
--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch-monitoring
-version: 0.2.3
+version: 0.2.4
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/elasticsearch-monitoring/templates/prometheusrule.yaml
+++ b/elasticsearch-monitoring/templates/prometheusrule.yaml
@@ -76,7 +76,7 @@ spec:
         severity: warning
         group: persistence
       annotations:
-        description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} has less than 10GB left'
+        description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} is low on free disk space'
         summary: AWS Elasticsearch low disk
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchawslowdiskspace'
     - alert: ElasticsearchAWSNoDiskSpace
@@ -86,7 +86,7 @@ spec:
         severity: critical
         group: persistence
       annotations:
-        description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} has less than 5GB left'
+        description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} has no free disk space'
         summary: AWS Elasticsearch out of disk
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchawsnodiskspace'
     {{- else }}

--- a/elasticsearch-monitoring/templates/prometheusrule.yaml
+++ b/elasticsearch-monitoring/templates/prometheusrule.yaml
@@ -70,23 +70,23 @@ spec:
     rules:
     {{- if .Values.amazonService.enabled }}
     - alert: ElasticsearchAWSLowDiskSpace
-      expr: aws_es_free_storage_space_minimum{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} <= 10240
+      expr: sum(label_join(aws_es_free_storage_space_minimum{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"}, "cluster", ":", "client_id", "domain_name")) by (cluster) / min(clamp_max(elasticsearch_filesystem_data_size_bytes{job="{{ .Release.Name }}-elasticsearch-exporter", es_data_node="true"}/1024/1024, 102400)) by (cluster) <= 0.1
       for: 15m
       labels:
         severity: warning
         group: persistence
       annotations:
-        description: 'AWS Elasticsearch cluster {{`{{ $labels.domain_namae }}`}} has less than 10GB left'
+        description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} has less than 10GB left'
         summary: AWS Elasticsearch low disk
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchawslowdiskspace'
     - alert: ElasticsearchAWSNoDiskSpace
-      expr: aws_es_free_storage_space_minimum{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} <= 5120
+      expr: sum(label_join(aws_es_free_storage_space_minimum{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"}, "cluster", ":", "client_id", "domain_name")) by (cluster) / min(clamp_max(elasticsearch_filesystem_data_size_bytes{job="{{ .Release.Name }}-elasticsearch-exporter", es_data_node="true"}/1024/1024, 102400)) by (cluster) <= 0.05
       for: 15m
       labels:
         severity: critical
         group: persistence
       annotations:
-        description: 'AWS Elasticsearch cluster {{`{{ $labels.domain_name }}`}} has less than 5GB left'
+        description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} has less than 5GB left'
         summary: AWS Elasticsearch out of disk
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchawsnodiskspace'
     {{- else }}


### PR DESCRIPTION
This will make the storage space alerts for AWS Elasticsearch clusters more flexible, as they adapt to the available storage in the cluster nodes.

In order to apply a binary arithmetic operator between the `aws_es_free_storage_space_minimum` and `elasticsearch_filesystem_data_size_bytes` metrics, I've needed to tweak a bit the metric labels to match on `cluster`.

Runbook changes: https://github.com/skyscrapers/documentation/pull/29

As per https://github.com/skyscrapers/engineering/issues/214