### PR TITLE
Update prometheus-operator chart

### DIFF
--- a/cloudwatch-monitoring/values.yaml
+++ b/cloudwatch-monitoring/values.yaml
@@ -30,11 +30,10 @@ prometheus-cloudwatch-exporter:
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #    memory: 128Mi
     # requests:
     #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
     #   memory: 128Mi
 
   aws:

--- a/cluster-monitoring/requirements.yaml
+++ b/cluster-monitoring/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: prometheus-operator
-  version: 1.7.0
+  version: 5.0.13
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/cluster-monitoring/requirements.yaml
+++ b/cluster-monitoring/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: prometheus-operator
-  version: 5.0.13
+  version: 5.2.0
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -40,7 +40,6 @@ elasticsearch-exporter:
     #   cpu: 100m
     #   memory: 128Mi
     # limits:
-    #   cpu: 100m
     #   memory: 128Mi
 
   service:
@@ -119,11 +118,10 @@ prometheus-cloudwatch-exporter:
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #    memory: 128Mi
     # requests:
     #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
     #   memory: 128Mi
 
   aws:

--- a/k8s-ec2-srcdst/values.yaml
+++ b/k8s-ec2-srcdst/values.yaml
@@ -13,11 +13,10 @@ nameOverride: ""
 fullnameOverride: ""
 
 resources:
-  limits:
-    cpu: 10m
-    memory: 64Mi
   requests:
     cpu: 10m
+    memory: 64Mi
+  limits:
     memory: 64Mi
 
 nodeSelector:

--- a/kubesignin/templates/dex.yaml
+++ b/kubesignin/templates/dex.yaml
@@ -78,11 +78,10 @@ spec:
               key: {{ $index }}-client-secret
 {{- end }}
         resources:
-          limits:
-            cpu: {{ .Values.Dex.Cpu }}
-            memory: {{ .Values.Dex.Memory }}
           requests:
             cpu: {{ .Values.Dex.Cpu }}
+            memory: {{ .Values.Dex.Memory }}
+          limits:
             memory: {{ .Values.Dex.Memory }}
       volumes:
       - name: config

--- a/kubesignin/templates/kubesignin.yaml
+++ b/kubesignin/templates/kubesignin.yaml
@@ -80,11 +80,10 @@ spec:
 {{- end }}
 
         resources:
-          limits:
-            cpu: {{ .Values.Kubesignin.Cpu }}
-            memory: {{ .Values.Kubesignin.Memory }}
           requests:
             cpu: {{ .Values.Kubesignin.Cpu }}
+            memory: {{ .Values.Kubesignin.Memory }}
+          limits:
             memory: {{ .Values.Kubesignin.Memory }}
 
       volumes:

--- a/kubesignin/values.yaml
+++ b/kubesignin/values.yaml
@@ -85,12 +85,11 @@ proxy:
     internalPort: 3000
     externalPort: 3000
   resources:
-    limits:
-      cpu: 2m
-      memory: 16Mi
     requests:
       cpu: 1m
-      memory: 8Mi
+      memory: 16Mi
+    limits:
+      memory: 16Mi
 
 # Keycloack proxies to setup
 proxies:


### PR DESCRIPTION
Required to disable monitoring for some control-plane components.

Warning, breaking change: The `DeadmansSwitch` alert has been renamed to `Watchdog` and thus need to be taken into account for the alertmanager routing. To be rolled out together with https://github.com/skyscrapers/kubernetes-stack/pull/43

Related issue: https://github.com/skyscrapers/engineering/issues/218