### PR TITLE
Remove our own Overcommitment rule

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: cluster-monitoring
-version: 1.3.0
+version: 1.3.1
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -42,20 +42,11 @@ spec:
   groups:
   - name: node-custom.rules
     rules:
-    - alert: MemoryOvercommitted
-      expr: round(((sum(kube_pod_container_resource_limits_memory_bytes) by (node) / sum(kube_node_status_capacity_memory_bytes ) by (node) )) *100) >=100
-      for: 1h
-      labels:
-        severity: info
-      annotations:
-        description: '{{`{{$labels.node}}`}} is overcommited by {{`{{$value}}`}}%'
-        summary: 'Instance {{`{{$labels.node}}`}} Memory usage high'
-        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-memoryovercommitted'
     - alert: CPUUsageHigh
       expr: 100 * (1 - avg by(instance)(irate(node_cpu{mode='idle'}[1h]))) >= 90
       for: 5m
       labels:
-        severity: warning
+        severity: info
       annotations:
         description: '{{`{{$labels.instance}}`}} is using more than 90% CPU for >1h '
         summary: 'Instance {{`{{$labels.instance}}`}} CPU usage high'


### PR DESCRIPTION
Since there's now an upstream check for Memory and CPU overcommitment: https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules/kubernetes-resources.yaml#L23-L74