### PR TITLE
Fix some release names

### DIFF
--- a/cloudwatch-monitoring/README.md
+++ b/cloudwatch-monitoring/README.md
@@ -33,7 +33,7 @@ The following tables lists the configurable parameters of cloudwatch-monitoring 
 Parameter | Description | Default
 --- | --- | ---
 `prometheus.app` | Sets the `app` label value (ServiceMonitor & Alerting rules) | `prometheus`
-`prometheus.name` | Sets the `prometheus` label value (ServiceMonitor & Alerting rules) | `k8s-monitor`
+`prometheus.name` | Sets the `prometheus` label value (ServiceMonitor & Alerting rules) | `cluster-monitoring`
 `prometheus.role` | Sets the `role` label value (Alerting rules) | `alert-rules`
 `interval` | Interval for how often Prometheus scrapes the cloudwatch-exporter | `30s`
 

--- a/cloudwatch-monitoring/values.yaml
+++ b/cloudwatch-monitoring/values.yaml
@@ -1,7 +1,7 @@
 ## Prometheus MatchLabel selectors
 prometheus:
   labels:
-    prometheus: "k8s-monitor"
+    prometheus: "cluster-monitoring"
 
 ## Interval for how often Prometheus scrapes the prometheus-cloudwatch-exporter
 interval: "300s"

--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: cluster-monitoring
-version: 1.3.2
+version: 1.3.3
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/README.md
+++ b/cluster-monitoring/README.md
@@ -88,7 +88,7 @@ With version `1.0.0` of this chart we move from using an old [`kube-prometheus`]
 
 ```sh
 helm delete --purge prometheus-operator
-helm delete --purge k8s-monitor
+helm delete --purge cluster-monitoring
 
 # Remove the `kubelet` svc created by prometheus-operator
 kubectl delete svc -n kube-system kubelet

--- a/cluster-monitoring/dashboards-default/grafana-dashboard-prometheus.json
+++ b/cluster-monitoring/dashboards-default/grafana-dashboard-prometheus.json
@@ -57,7 +57,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "prometheus_build_info{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}",
+          "expr"          : "prometheus_build_info{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}",
           "format"        : "time_series",
           "intervalFactor": 1,
           "legendFormat"  : "{{version}} - {{revision}}",
@@ -141,7 +141,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "time() - min(process_start_time_seconds{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "time() - min(process_start_time_seconds{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 1,
           "legendFormat"  : "Uptime",
@@ -228,14 +228,14 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(process_max_fds{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(process_max_fds{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 1,
           "legendFormat"  : "Max",
           "refId"         : "A"
         },
         {
-          "expr"          : "sum(process_open_fds{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(process_open_fds{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 1,
           "legendFormat"  : "Open",
@@ -338,7 +338,7 @@
       "steppedLine": false,
       "targets"    : [
         {
-          "expr"          : "sum(process_resident_memory_bytes{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(process_resident_memory_bytes{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "intervalFactor": 2,
           "legendFormat"  : "RSS",
           "metric"        : "process_resident_memory_bytes",
@@ -346,7 +346,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(prometheus_local_storage_target_heap_size_bytes{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(prometheus_local_storage_target_heap_size_bytes{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "intervalFactor": 2,
           "legendFormat"  : "Target heap size",
           "metric"        : "go_memstats_alloc_bytes",
@@ -354,7 +354,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(go_memstats_next_gc_bytes{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(go_memstats_next_gc_bytes{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "intervalFactor": 2,
           "legendFormat"  : "Next GC",
           "metric"        : "go_memstats_next_gc_bytes",
@@ -362,7 +362,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(go_memstats_alloc_bytes{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(go_memstats_alloc_bytes{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "intervalFactor": 2,
           "legendFormat"  : "Allocated",
           "metric"        : "go_memstats_alloc_bytes",
@@ -454,7 +454,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(irate(process_cpu_seconds_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(irate(process_cpu_seconds_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "intervalFactor": 2,
           "legendFormat"  : "Irate",
           "metric"        : "prometheus_local_storage_ingested_samples_total",
@@ -462,7 +462,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(rate(process_cpu_seconds_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[5m])) without (instance)",
+          "expr"          : "sum(rate(process_cpu_seconds_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[5m])) without (instance)",
           "intervalFactor": 2,
           "legendFormat"  : "5m rate",
           "metric"        : "prometheus_local_storage_ingested_samples_total",
@@ -554,7 +554,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_head_samples_appended_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_head_samples_appended_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "samples/s",
@@ -649,7 +649,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(prometheus_tsdb_head_series{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(prometheus_tsdb_head_series{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Time series",
@@ -743,7 +743,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(prometheus_tsdb_head_active_appenders{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(prometheus_tsdb_head_active_appenders{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Head Appenders",
@@ -842,7 +842,7 @@
       "steppedLine": false,
       "targets"    : [
         {
-          "expr"          : "sum(prometheus_tsdb_blocks_loaded{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(prometheus_tsdb_blocks_loaded{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Blocks Loaded",
@@ -942,7 +942,7 @@
       "steppedLine": false,
       "targets"    : [
         {
-          "expr"          : "sum(prometheus_tsdb_head_chunks{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(prometheus_tsdb_head_chunks{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Chunks",
@@ -1036,7 +1036,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_head_chunks_created_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_head_chunks_created_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Created",
@@ -1131,7 +1131,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_head_chunks_removed_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_head_chunks_removed_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Removed",
@@ -1234,7 +1234,7 @@
       "steppedLine": false,
       "targets"    : [
         {
-          "expr"          : "sum(prometheus_tsdb_head_min_time{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(prometheus_tsdb_head_min_time{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Min",
@@ -1251,7 +1251,7 @@
           "refId"         : "C"
         },
         {
-          "expr"          : "sum(prometheus_tsdb_head_max_time{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}) without (instance)",
+          "expr"          : "sum(prometheus_tsdb_head_max_time{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Max",
@@ -1346,7 +1346,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "GC Time/s",
@@ -1403,7 +1403,7 @@
         "Failed Compactions"                                                                        : "#bf1b00",
         "Max chunks"                                                                                : "#052B51",
         "Max to persist"                                                                            : "#3F6833",
-        "{instance=\"demo.robustperception.io:9090\",job=\"k8s-monitor-prometheus-ope-prometheus\"}": "#bf1b00"
+        "{instance=\"demo.robustperception.io:9090\",job=\"cluster-monitoring-prometh-prometheus\"}": "#bf1b00"
       },
       "bars"      : false,
       "dashLength": 10,
@@ -1442,7 +1442,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_wal_corruptions_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_wal_corruptions_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1452,7 +1452,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(rate(prometheus_tsdb_reloads_failures_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_reloads_failures_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1462,7 +1462,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(rate(prometheus_tsdb_head_series_not_found{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_head_series_not_found{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1472,7 +1472,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(rate(prometheus_tsdb_compactions_failed_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_compactions_failed_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1482,7 +1482,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1579,7 +1579,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_reloads_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_reloads_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1675,7 +1675,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance) / sum(rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance) / sum(rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1685,7 +1685,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance) / sum(rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance) / sum(rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1782,7 +1782,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_retention_cutoffs_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_retention_cutoffs_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Retention Cutoffs",
@@ -1877,7 +1877,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_compactions_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_compactions_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "interval"      : "",
           "intervalFactor": 2,
@@ -1972,7 +1972,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "",
@@ -2066,7 +2066,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance) / sum(rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance) / sum(rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Chunk Samples",
@@ -2160,7 +2160,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance) / sum(rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance) / sum(rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Chunk Time Range",
@@ -2255,7 +2255,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance) / sum(rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance) / sum(rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[10m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Bytes/Sample",
@@ -2351,7 +2351,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_http_request_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_http_request_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "{{handler}}",
@@ -2446,7 +2446,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_http_request_duration_seconds_count{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_http_request_duration_seconds_count{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "{{handler}}",
@@ -2541,7 +2541,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_http_request_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance) / sum(rate(prometheus_http_request_duration_seconds_count{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_http_request_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance) / sum(rate(prometheus_http_request_duration_seconds_count{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "{{handler}}",
@@ -2636,7 +2636,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_engine_query_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_engine_query_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "{{slice}}",
@@ -2734,7 +2734,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(label_replace(prometheus_rule_group_last_duration_seconds{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}, \"rule_group_name\", \"$1\", \"rule_group\", \".*;(.*)$\")) without (instance)",
+          "expr"          : "sum(label_replace(prometheus_rule_group_last_duration_seconds{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}, \"rule_group_name\", \"$1\", \"rule_group\", \".*;(.*)$\")) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "{{rule_group_name}}",
@@ -2828,7 +2828,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_rule_group_iterations_missed_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_rule_group_iterations_missed_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Rule group missed",
@@ -2837,7 +2837,7 @@
           "step"          : 10
         },
         {
-          "expr"          : "sum(rate(prometheus_rule_evaluation_failures_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_rule_evaluation_failures_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Rule evals failed",
@@ -2931,7 +2931,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(prometheus_rule_group_duration_seconds_sum{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(prometheus_rule_group_duration_seconds_sum{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "format"        : "time_series",
           "intervalFactor": 2,
           "legendFormat"  : "Rule evaluation duration",
@@ -3027,7 +3027,7 @@
       "steppedLine"    : false,
       "targets"        : [
         {
-          "expr"          : "sum(rate(go_memstats_alloc_bytes_total{job=\"k8s-monitor-prometheus-ope-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
+          "expr"          : "sum(rate(go_memstats_alloc_bytes_total{job=\"cluster-monitoring-prometh-prometheus\",pod=\"$Prometheus\"}[1m])) without (instance)",
           "intervalFactor": 2,
           "legendFormat"  : "Allocated Bytes/s",
           "metric"        : "go_memstats_alloc_bytes",
@@ -3092,7 +3092,7 @@
         "multi"         : false,
         "name"          : "Prometheus",
         "options"       : [],
-        "query"         : "label_values(up{job=\"k8s-monitor-prometheus-ope-prometheus\"}, pod)",
+        "query"         : "label_values(up{job=\"cluster-monitoring-prometh-prometheus\"}, pod)",
         "refresh"       : 2,
         "regex"         : "",
         "skipUrlSync"   : false,

--- a/cluster-monitoring/templates/servicemonitor.yaml
+++ b/cluster-monitoring/templates/servicemonitor.yaml
@@ -38,4 +38,4 @@ spec:
   selector:
     matchLabels:
       app: aws-cluster-autoscaler
-      release: k8s-autoscaler
+      release: cluster-autoscaler

--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch-monitoring
-version: 0.2.4
+version: 0.2.5
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/elasticsearch-monitoring/README.md
+++ b/elasticsearch-monitoring/README.md
@@ -46,7 +46,7 @@ The following tables lists the configurable parameters of elasticsearch-monitori
 Parameter | Description | Default
 --- | --- | ---
 `prometheus.app` | Sets the `app` label value (ServiceMonitor & Alerting rules) | `prometheus`
-`prometheus.name` | Sets the `prometheus` label value (ServiceMonitor & Alerting rules) | `k8s-monitor`
+`prometheus.name` | Sets the `prometheus` label value (ServiceMonitor & Alerting rules) | `cluster-monitoring`
 `prometheus.role` | Sets the `role` label value (Alerting rules) | `alert-rules`
 `esExporterScrapeInterval` | Interval for how often Prometheus scrapes the elasticsearch-exporter | `60s`
 `esExporterScrapeTimeout` | Tiemout for the elasticsearch-exporter Prometheus scraper | `30s`

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -1,7 +1,7 @@
 ## Prometheus MatchLabel selectors
 prometheus:
   labels:
-    prometheus: "k8s-monitor"
+    prometheus: "cluster-monitoring"
 
 ## Interval for how often Prometheus scrapes the elasticsearch-exporter
 esExporterScrapeInterval: "60s"

--- a/mongodb-monitoring/Chart.yaml
+++ b/mongodb-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-monitoring
-version: 1.0.1
+version: 1.0.2
 description: MongoDB monitoring using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/mongodb-monitoring/values.yaml
+++ b/mongodb-monitoring/values.yaml
@@ -1,7 +1,7 @@
 ## Prometheus MatchLabel selectors
 prometheus:
   labels:
-    prometheus: "k8s-monitor"
+    prometheus: "cluster-monitoring"
 
 nodes:
 - 10.1.2.3


### PR DESCRIPTION
Due to the recent refactor (https://github.com/skyscrapers/engineering/issues/203):
- k8s-monitor was renamed to cluster-monitoring
- k8s-autoscaler was renamed to cluster-autoscaler

There were some remains of the old names in the charts

The cluster-monitoring name is actually quite important as it's used to create all the monitoring targets.