### PR TITLE
Kubesignin: Allow setting dex extra callback uris

### DIFF
--- a/kubesignin/templates/dex-config.yaml
+++ b/kubesignin/templates/dex-config.yaml
@@ -99,5 +99,8 @@ data:
 {{- range $key, $value := .Values.proxies }}
         - "https://{{ $value.oidc.redirectURL }}/oauth/callback"
 {{- end }}
+{{- range .Values.RedirectUris }}
+        - {{ . | quote }}
+{{- end }}
       name: "kubesignin"
       secret: {{.Values.Kubesignin.ClientSecret}}

--- a/kubesignin/values.yaml
+++ b/kubesignin/values.yaml
@@ -36,6 +36,8 @@ Dex:
         teams:
           - someteam
 
+  RedirectUris: []
+
   # StaticPassword:
   #   Email: "admin@example.com"
   #   Hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
@@ -78,9 +80,6 @@ proxy:
     repository: "quay.io/gambol99/keycloak-proxy"
     tag: "v2.2.2"
     pullPolicy: "IfNotPresent"
-  oidc:
-    discoveryURL: https://kubesigin.domain/dex
-    appRoot: "/"
   service:
     internalPort: 3000
     externalPort: 3000


### PR DESCRIPTION
Change needed for adding extra redirectUris (eg. OIDC proxies not managed by this chart)

Reference: skyscrapers/engineering#203