### PR TITLE
Update prometheus operator chart version

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 name: cluster-monitoring
-version: 1.4.0
+version: 1.4.1
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/requirements.yaml
+++ b/cluster-monitoring/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: prometheus-operator
-  version: 5.2.0
+  version: 6.0.0
   repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
According to [the documentation](https://github.com/helm/charts/tree/master/stable/prometheus-operator#upgrading-from-5xx-to-6xx), a `helm upgrade --force` might be needed.

As per https://github.com/skyscrapers/engineering/issues/268