### PR TITLE
Add optional node_exporter scraping for mongodb-monitoring

### DIFF
--- a/mongodb-monitoring/Chart.yaml
+++ b/mongodb-monitoring/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 name: mongodb-monitoring
-version: 1.0.2
+version: 1.1.0
 description: MongoDB monitoring using Prometheus-operator and Grafana.
 keywords:
   - grafana
-  - kube-prometheus
+  - prometheus-operator
   - monitoring
   - prometheus
   - mongodb

--- a/mongodb-monitoring/templates/mongodb_endpoint.yaml
+++ b/mongodb-monitoring/templates/mongodb_endpoint.yaml
@@ -16,3 +16,7 @@ subsets:
   ports:
   - port: 9216
     name: metrics
+  {{ if .Values.nodeMetricsEnabled }}
+  - port: {{ .Values.nodeMetricsPort }}
+    name: metrics-node
+  {{ end }}

--- a/mongodb-monitoring/templates/service.yaml
+++ b/mongodb-monitoring/templates/service.yaml
@@ -14,3 +14,9 @@ spec:
       targetPort: 9216
       protocol: TCP
       name: metrics
+    {{ if .Values.nodeMetricsEnabled }}
+    - port: {{ .Values.nodeMetricsPort }}
+      targetPort: {{ .Values.nodeMetricsPort }}
+      protocol: TCP
+      name: metrics-node
+    {{ end }}

--- a/mongodb-monitoring/templates/servicemonitor.yaml
+++ b/mongodb-monitoring/templates/servicemonitor.yaml
@@ -21,3 +21,30 @@ spec:
       release: {{ .Release.Name }}
       heritage: {{ .Release.Service }}
       component: mongodb
+
+{{ if .Values.nodeMetricsEnabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+{{ include "labels" $ | indent 4 }}
+    {{- range $key, $val := .Values.prometheus.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end}}
+  name: "{{ .Release.Name }}"-node-exporter
+spec:
+  endpoints:
+    - interval: {{ .Values.interval }}
+      port: metrics-node
+  namespaceSelector:
+    matchNames:
+      - "{{ .Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: {{ template "app.name" . }}
+      chart: {{ template "app.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      component: mongodb
+{{ end }}

--- a/mongodb-monitoring/values.yaml
+++ b/mongodb-monitoring/values.yaml
@@ -9,3 +9,9 @@ nodes:
 - 10.3.2.1
 
 interval: 60s
+
+# Whether to include node_exporter scraping
+nodeMetricsEnabled: false
+
+# Port where the node_exporter metrics are exposed
+nodeMetricsPort: 9100


### PR DESCRIPTION
Similar to https://github.com/skyscrapers/charts/pull/80, allow scraping the node_exporter on mongodb instances, if available.