### PR TITLE
Switch "approx_number_of_messages... metrics to average

### DIFF
--- a/cluster-monitoring/dashboards-extra/grafana-dashboard-sqs.json
+++ b/cluster-monitoring/dashboards-extra/grafana-dashboard-sqs.json
@@ -241,21 +241,21 @@
           "steppedLine"    : false,
           "targets"        : [
             {
-              "expr"          : "aws_sqs_approximate_number_of_messages_visible_sum{queue_name=~\"$queue_name\"}",
+              "expr"          : "aws_sqs_approximate_number_of_messages_visible_average{queue_name=~\"$queue_name\"}",
               "format"        : "time_series",
               "intervalFactor": 2,
               "legendFormat"  : "aws_sqs_approximate_number_of_messages_visible",
               "refId"         : "A"
             },
             {
-              "expr"          : "aws_sqs_approximate_number_of_messages_not_visible_sum{queue_name=~\"$queue_name\"}",
+              "expr"          : "aws_sqs_approximate_number_of_messages_not_visible_average{queue_name=~\"$queue_name\"}",
               "format"        : "time_series",
               "intervalFactor": 2,
               "legendFormat"  : "aws_sqs_approximate_number_of_messages_not_visible",
               "refId"         : "B"
             },
             {
-              "expr"          : "aws_sqs_approximate_number_of_messages_delayed_sum{queue_name=~\"$queue_name\"}",
+              "expr"          : "aws_sqs_approximate_number_of_messages_delayed_average{queue_name=~\"$queue_name\"}",
               "format"        : "time_series",
               "intervalFactor": 2,
               "legendFormat"  : "aws_sqs_approximate_number_of_messages_delayed",


### PR DESCRIPTION
Apparently AWS changed the way they report SUM statistics for these metrics, and the relevant statistic is average

As per https://github.com/skyscrapers/apptweak/issues/320

Of course this requires the Cloudwatch exporter to be configured to retrieve the average statistic