### PR TITLE
Update securityContext on cloudwatch-exporter for IRSA

### DIFF
--- a/concourse-monitoring/Chart.yaml
+++ b/concourse-monitoring/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   - name: prometheus-cloudwatch-exporter

--- a/concourse-monitoring/values.yaml
+++ b/concourse-monitoring/values.yaml
@@ -31,10 +31,18 @@ prometheus-cloudwatch-exporter:
 
   aws:
     region: eu-west-1
-    role:
+    ## kube2iam
+    # role: <arn>
 
   serviceAccount:
     create: true
+    ## IRSA
+    # annotations:
+    #   eks.amazonaws.com/role-arn: <arn>
+
+  securityContext:
+    runAsUser: 65534
+    fsGroup: 65534
 
   rbac:
     create: true

--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 name: elasticsearch-monitoring
 type: application
-version: 1.2.0
+version: 1.2.1
 keywords:
   - grafana
   - kube-prometheus

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -238,30 +238,21 @@ prometheus-cloudwatch-exporter:
     #   memory: 160Mi
 
   aws:
-    role:
-
-    # The name of a pre-created secret in which AWS credentials are stored. When
-    # set, aws_access_key_id is assumed to be in a field called access_key,
-    # aws_secret_access_key is assumed to be in a field called secret_key, and the
-    # session token, if it exists, is assumed to be in a field called
-    # security_token
-    secret:
-      name:
-      includesSessionToken: false
-
-    # Note: Do not specify the aws_access_key_id and aws_secret_access_key if you specified role or secret.name before
-    aws_access_key_id:
-    aws_secret_access_key:
+    region: eu-west-1
+    ## kube2iam
+    # role: <arn>
 
   serviceAccount:
-    # Specifies whether a ServiceAccount should be created
     create: true
-    # The name of the ServiceAccount to use.
-    # If not set and create is true, a name is generated using the fullname template
-    name:
+    ## IRSA
+    # annotations:
+    #   eks.amazonaws.com/role-arn: <arn>
+
+  securityContext:
+    runAsUser: 65534
+    fsGroup: 65534
 
   rbac:
-    # Specifies whether RBAC resources should be created
     create: true
 
   config: |-

--- a/rds-monitoring/Chart.yaml
+++ b/rds-monitoring/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   - name: prometheus-cloudwatch-exporter

--- a/rds-monitoring/values.yaml
+++ b/rds-monitoring/values.yaml
@@ -32,10 +32,18 @@ prometheus-cloudwatch-exporter:
 
   aws:
     region: eu-west-1
-    role:
+    ## kube2iam
+    # role: <arn>
 
   serviceAccount:
     create: true
+    ## IRSA
+    # annotations:
+    #   eks.amazonaws.com/role-arn: <arn>
+
+  securityContext:
+    runAsUser: 65534
+    fsGroup: 65534
 
   rbac:
     create: true

--- a/redshift-monitoring/Chart.yaml
+++ b/redshift-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Redshift monitoring using Prometheus-operator and Grafana.
 name: redshift-monitoring
 type: application
-version: 1.3.0
+version: 1.3.1
 keywords:
   - grafana
   - prometheus-operator

--- a/redshift-monitoring/values.yaml
+++ b/redshift-monitoring/values.yaml
@@ -39,20 +39,20 @@ prometheus-cloudwatch-exporter:
 
   aws:
     region: eu-west-1
-    role:
-    # Note: Do not specify the aws_access_key_id abd aws_secret_access_key if you specified role before
-    aws_access_key_id:
-    aws_secret_access_key:
+    ## kube2iam
+    # role: <arn>
 
   serviceAccount:
-    # Specifies whether a ServiceAccount should be created
     create: true
-    # The name of the ServiceAccount to use.
-    # If not set and create is true, a name is generated using the fullname template
-    name:
+    ## IRSA
+    # annotations:
+    #   eks.amazonaws.com/role-arn: <arn>
+
+  securityContext:
+    runAsUser: 65534
+    fsGroup: 65534
 
   rbac:
-    # Specifies whether RBAC resources should be created
     create: true
 
   config: |-


### PR DESCRIPTION
It's important to set fsGroup the same as runAsUser, otherwise cloudwatch-exporter can't read the secret token.

As per https://github.com/skyscrapers/engineering/issues/290