### PR TITLE
Update prometheus operator chart version

### DIFF
--- a/cluster-monitoring/requirements.yaml
+++ b/cluster-monitoring/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: prometheus-operator
   # https://github.com/helm/charts/issues/22081
-  version: 8.12.13
+  version: 9.3.0
   repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
The 9.x release of the prometheus-operator chart contains a [breaking change](https://github.com/helm/charts/tree/master/stable/prometheus-operator#upgrading-from-8xx-to-9xx), but it should affect us, as we don't use the `additionalScrapeConfigsExternal` chart value.