### PR TITLE
Fix certmanager certificate status alert

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cluster-monitoring
-version: 1.9.2
+version: 1.9.3
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -68,7 +68,7 @@ spec:
   - name: certmanager-certificate-status.rules
     rules:
     - alert: CertificateNotReady
-      expr: certmanager_certificate_ready_status != 1
+      expr: certmanager_certificate_ready_status{condition="True"} != 1
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Apparently cert-manager has a very strange way of reporting a certificate status to prometheus. For each certificate it reports the same metric with three different "condition" values (True, False and Unknown). If I understood it correctly, a certificate is ready when the metric with the condition label set to True is 1.

I'd like somebody to double-check my assumptions on the behaviour of the alert 🙏 

References
https://github.com/jetstack/cert-manager/blob/master/pkg/metrics/certificates.go#L77
https://github.com/jetstack/cert-manager/blob/46eaf3d1a4b5e977b612393300f0f11978ebf72e/pkg/metrics/certificates_test.go#L65-L67