### PR TITLE
Configure VPA monitoring per skyscrapers/engineering#247

### DIFF
--- a/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.8.1
 name: vertical-pod-autoscaler
 type: application
 description: A Helm chart to install vertical-pod-autoscaler inside a Kubernetes cluster.
-version: 0.1.3
+version: 0.2.0
 maintainers:
 - name: skyscrapers
 sources:

--- a/vertical-pod-autoscaler/templates/admission-controller-service-monitor.yaml
+++ b/vertical-pod-autoscaler/templates/admission-controller-service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.admissionController.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "vpa.fullname" . }}-admission-controller
+  labels:
+    app.kubernetes.io/component: admission-controller
+    {{- include "vpa.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - interval: {{ .Values.admissionController.servicemonitor.scrapeInterval }}
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - "{{ .Release.Namespace }}"
+  selector:
+    matchLabels:
+      name: vpa-webhook
+{{- end }}
+

--- a/vertical-pod-autoscaler/templates/admission-controller-service.yaml
+++ b/vertical-pod-autoscaler/templates/admission-controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.admissionController.enabled }}
+{{- if .Values.admissionController.servicemonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,6 +7,8 @@ spec:
   ports:
     - port: 443
       targetPort: 8000
+    - port: metrics
+      targerPort: 8944
   selector:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.selectorLabels" . | nindent 4 }}

--- a/vertical-pod-autoscaler/templates/admission-controller-service.yaml
+++ b/vertical-pod-autoscaler/templates/admission-controller-service.yaml
@@ -7,8 +7,10 @@ spec:
   ports:
     - port: 443
       targetPort: 8000
+    {{- if .Values.admissionController.servicemonitor.enabled }}
     - port: metrics
       targerPort: 8944
+    {{- end }}
   selector:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.selectorLabels" . | nindent 4 }}

--- a/vertical-pod-autoscaler/templates/admission-controller-service.yaml
+++ b/vertical-pod-autoscaler/templates/admission-controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.admissionController.servicemonitor.enabled }}
+{{- if .Values.admissionController.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -45,6 +45,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: metrics
+              containerPort: 8942
+              protocol: TCP
           resources:
             {{- toYaml .Values.recommender.resources | nindent 12 }}
       {{- with .Values.recommender.nodeSelector }}

--- a/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -45,9 +45,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.recommender.servicemonitor.enabled }}
             - name: metrics
               containerPort: 8942
               protocol: TCP
+            {{- end }}
           resources:
             {{- toYaml .Values.recommender.resources | nindent 12 }}
       {{- with .Values.recommender.nodeSelector }}

--- a/vertical-pod-autoscaler/templates/recommender-pod-monitor.yaml
+++ b/vertical-pod-autoscaler/templates/recommender-pod-monitor.yaml
@@ -16,6 +16,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: recommender
-      {{- include "vpa.labels" . | nindent 6 }}
+      {{- include "vpa.selectorLabels" . | nindent 6 }}
 {{- end }}
 

--- a/vertical-pod-autoscaler/templates/recommender-pod-monitor.yaml
+++ b/vertical-pod-autoscaler/templates/recommender-pod-monitor.yaml
@@ -16,5 +16,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: recommender
+      {{- include "vpa.labels" . | nindent 6 }}
 {{- end }}
 

--- a/vertical-pod-autoscaler/templates/recommender-pod-monitor.yaml
+++ b/vertical-pod-autoscaler/templates/recommender-pod-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.recommender.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "vpa.fullname" . }}-recommender
+  labels:
+    app.kubernetes.io/component: recommender
+    {{- include "vpa.labels" . | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+  - interval: {{ .Values.recommender.servicemonitor.scrapeInterval }}
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - "{{ .Release.Namespace }}"
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: recommender
+{{- end }}
+

--- a/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -45,9 +45,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.updater.servicemonitor.enabled }}
             - name: metrics
               containerPort: 8943
               protocol: TCP
+            {{- end }}
           resources:
             {{- toYaml .Values.updater.resources | nindent 12 }}
       {{- with .Values.updater.nodeSelector }}

--- a/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -45,6 +45,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: metrics
+              containerPort: 8943
+              protocol: TCP
           resources:
             {{- toYaml .Values.updater.resources | nindent 12 }}
       {{- with .Values.updater.nodeSelector }}

--- a/vertical-pod-autoscaler/templates/updater-pod-monitor.yaml
+++ b/vertical-pod-autoscaler/templates/updater-pod-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.updater.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "vpa.fullname" . }}-updater
+  labels:
+    app.kubernetes.io/component: updater
+    {{- include "vpa.labels" . | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+  - interval: {{ .Values.updater.servicemonitor.scrapeInterval }}
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - "{{ .Release.Namespace }}"
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: updater
+{{- end }}
+

--- a/vertical-pod-autoscaler/templates/updater-pod-monitor.yaml
+++ b/vertical-pod-autoscaler/templates/updater-pod-monitor.yaml
@@ -16,6 +16,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: updater
-      {{- include "vpa.labels" . | nindent 6 }}
+      {{- include "vpa.selectorLabels" . | nindent 6 }}
 {{- end }}
 

--- a/vertical-pod-autoscaler/templates/updater-pod-monitor.yaml
+++ b/vertical-pod-autoscaler/templates/updater-pod-monitor.yaml
@@ -16,5 +16,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: updater
+      {{- include "vpa.labels" . | nindent 6 }}
 {{- end }}
 

--- a/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/values.yaml
@@ -55,6 +55,9 @@ recommender:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  servicemonitor:
+    enabled: true
+    scrapeInterval: 60s
 
 updater:
   # updater.enabled -- If true, the updater component will be deployed
@@ -92,6 +95,9 @@ updater:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  servicemonitor:
+    enabled: true
+    scrapeInterval: 60s
 
 admissionController:
   # admissionController.enabled -- If true, will install the admission-controller component of vpa
@@ -127,3 +133,6 @@ admissionController:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  servicemonitor:
+    enabled: true
+    scrapeInterval: 60s


### PR DESCRIPTION
This PR configures:
- pod monitoring for 
  - recommender
  - updater
- service monitoring for
  - admission-controller