### PR TITLE
Bugfix: multiple matches for labels: 

### DIFF
--- a/rds-monitoring/Chart.yaml
+++ b/rds-monitoring/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.2.4
 
 dependencies:
   - name: prometheus-cloudwatch-exporter

--- a/rds-monitoring/templates/prometheusrules.yaml
+++ b/rds-monitoring/templates/prometheusrules.yaml
@@ -41,7 +41,7 @@ spec:
             message: 'RDS instance {{`{{ $labels.dbinstance_identifier }}`}} is running very low on memory (< 10Mb)!'
             runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-rdsfreeablememorylow'
         - alert: RDSFreeStorageSpaceRunningLow
-          expr: predict_linear(aws_rds_free_storage_space_average{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"}[6h], 3600 * 24 * 4) * on (instance) group_left up{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} {{ include "rds-monitoring.filterOnTag" . }} < 0
+          expr: predict_linear(aws_rds_free_storage_space_average{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"}[6h], 3600 * 24 * 4) * on (instance) group_left up{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} {{ include "rds-monitoring.filterOnTag" . }} group_left < 0
           for: 6h
           labels:
             severity: critical

--- a/rds-monitoring/templates/prometheusrules.yaml
+++ b/rds-monitoring/templates/prometheusrules.yaml
@@ -41,7 +41,7 @@ spec:
             message: 'RDS instance {{`{{ $labels.dbinstance_identifier }}`}} is running very low on memory (< 10Mb)!'
             runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-rdsfreeablememorylow'
         - alert: RDSFreeStorageSpaceRunningLow
-          expr: predict_linear(aws_rds_free_storage_space_average{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"}[6h], 3600 * 24 * 4) * on (instance) group_left up{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} {{ include "rds-monitoring.filterOnTag" . }} group_left < 0
+          expr: predict_linear(aws_rds_free_storage_space_average{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter", container="prometheus-cloudwatch-exporter"}[6h], 3600 * 24 * 4) * on (instance) group_left up{job="{{ .Release.Name }}-prometheus-cloudwatch-exporter"} {{ include "rds-monitoring.filterOnTag" . }} < 0
           for: 6h
           labels:
             severity: critical


### PR DESCRIPTION
Adding the left join solves the problem of
```
Error executing query: multiple matches for labels: many-to-one matching must be explicit (group_left/group_right)
```