### PR TITLE
Update cloudwatch exporter chart

### DIFF
--- a/concourse-monitoring/Chart.lock
+++ b/concourse-monitoring/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: prometheus-cloudwatch-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.8.0
-digest: sha256:97ccb29b7fdf61b20b5adb02c752a54f55ee638b2110c9a97dbd3b58132334f8
-generated: "2020-06-11T16:45:57.4683856+02:00"

--- a/concourse-monitoring/Chart.yaml
+++ b/concourse-monitoring/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.3
 
 dependencies:
   - name: prometheus-cloudwatch-exporter
-    version: 0.12.0
+    version: 0.12.1
     repository: https://prometheus-community.github.io/helm-charts

--- a/elasticsearch-monitoring/Chart.lock
+++ b/elasticsearch-monitoring/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: elasticsearch-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 2.1.1
-- name: prometheus-cloudwatch-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.8.0
-digest: sha256:637c67330c7ae6f2632243fc0b1f95ab310b21b947758719bea20cdc9dc49b9b
-generated: "2020-06-11T16:46:26.1596653+02:00"

--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 name: elasticsearch-monitoring
 type: application
-version: 1.2.2
+version: 1.2.3
 keywords:
   - grafana
   - kube-prometheus
@@ -23,5 +23,5 @@ dependencies:
     version: 4.0.0
     repository: https://prometheus-community.github.io/helm-charts
   - name: prometheus-cloudwatch-exporter
-    version: 0.12.0
+    version: 0.12.1
     repository: https://prometheus-community.github.io/helm-charts

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -200,11 +200,6 @@ prometheus-cloudwatch-exporter:
 
   replicaCount: 1
 
-  image:
-    repository: prom/cloudwatch-exporter
-    tag: cloudwatch_exporter-0.7.0
-    pullPolicy: IfNotPresent
-
   # Example proxy configuration:
   # command:
   #   - 'java'

--- a/rds-monitoring/Chart.lock
+++ b/rds-monitoring/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: prometheus-cloudwatch-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.8.0
-digest: sha256:97ccb29b7fdf61b20b5adb02c752a54f55ee638b2110c9a97dbd3b58132334f8
-generated: "2020-06-11T16:46:47.5537386+02:00"

--- a/rds-monitoring/Chart.yaml
+++ b/rds-monitoring/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.4
+version: 0.2.5
 
 dependencies:
   - name: prometheus-cloudwatch-exporter
-    version: 0.12.0
+    version: 0.12.1
     repository: https://prometheus-community.github.io/helm-charts

--- a/redshift-monitoring/Chart.lock
+++ b/redshift-monitoring/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: prometheus-cloudwatch-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.8.0
-digest: sha256:97ccb29b7fdf61b20b5adb02c752a54f55ee638b2110c9a97dbd3b58132334f8
-generated: "2020-06-11T16:47:38.3855217+02:00"

--- a/redshift-monitoring/Chart.yaml
+++ b/redshift-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Redshift monitoring using Prometheus-operator and Grafana.
 name: redshift-monitoring
 type: application
-version: 1.3.2
+version: 1.3.3
 keywords:
   - grafana
   - prometheus-operator
@@ -16,5 +16,5 @@ maintainers:
     email: hello@skyscrapers.eu
 dependencies:
   - name: prometheus-cloudwatch-exporter
-    version: 0.12.0
+    version: 0.12.1
     repository: https://prometheus-community.github.io/helm-charts

--- a/redshift-monitoring/values.yaml
+++ b/redshift-monitoring/values.yaml
@@ -12,11 +12,6 @@ prometheus-cloudwatch-exporter:
 
   replicaCount: 1
 
-  image:
-    repository: prom/cloudwatch-exporter
-    tag: latest
-    pullPolicy: IfNotPresent
-
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
Remove the actual component version from values. Rely on the one provided by the chart.
Also remove the lock file, not needed.