### PR TITLE
Add cluster-monitoring alert for eip-unnavailbe taint

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cluster-monitoring
-version: 1.12.4
+version: 1.12.5
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -54,6 +54,15 @@ spec:
         summary: 'Node {{`{{$labels.node}}`}} has Impaired Volumes'
         description: 'EBS volumes are failing to attach to node {{`{{$labels.node}}`}}'
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-nodewithimpairedvolumes'
+    - alert: NodeWithoutEIP
+      expr: count by(node)(kube_node_spec_taint{key="node.kubernetes.io/eip-unavailable", effect="NoSchedule"}) > 0
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: 'No EIP on {{`{{$labels.node}}`}}'
+        description: 'Node {{`{{$labels.node}}`}} failed to auto-assign an EIP'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-nodewithouteip'
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Add a Node prometheusrule to throw an alert when the `node.kubernetes.io/eip-unavailable:NoSchedule` taint is detected

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/engineering/issues/455

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Notify us in case of problems

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running on internal test cluster

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
