### PR TITLE
Fix ES exporter values scope

### DIFF
--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 name: elasticsearch-monitoring
 type: application
-version: 1.2.3
+version: 1.2.4
 keywords:
   - grafana
   - kube-prometheus

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -15,7 +15,7 @@ amazonService: true
 ## ------------------------------ ##
 
 ## The following settings come from the elasticsearch-exporter chart
-elasticsearch-exporter:
+prometheus-elasticsearch-exporter:
   ## number of exporter instances
   ##
   replicaCount: 1


### PR DESCRIPTION
We renamed the sub-chart dependency but we didn't rename the values scope, so the exporter sub-chart was taking the default values