### PR TITLE
Add new alert on ES monitoring chart

### DIFF
--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 name: elasticsearch-monitoring
 type: application
-version: 1.2.5
+version: 1.2.6
 keywords:
   - grafana
   - kube-prometheus

--- a/elasticsearch-monitoring/templates/prometheusrule.yaml
+++ b/elasticsearch-monitoring/templates/prometheusrule.yaml
@@ -86,6 +86,16 @@ spec:
         description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} has no free disk space'
         summary: AWS Elasticsearch out of disk
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchawsnodiskspace'
+    - alert: ElasticsearchIndexWritesBlocked
+      expr: max(label_join(aws_es_cluster_index_writes_blocked_maximum{job="{{ include "elasticsearch-monitoring.cloudwatchExporterName" . }}"}, "cluster", ":", "client_id", "domain_name")) by (cluster) > 0
+      for: 10m
+      labels:
+        severity: critical
+        group: persistence
+      annotations:
+        description: 'AWS Elasticsearch cluster {{`{{ $labels.cluster }}`}} is blocking incoming write requests'
+        summary: AWS ElasticSearch is blocking write requests
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-elasticsearchindexwritesblocked'
     {{- else }}
     - alert: ElasticsearchLowDiskSpace
       expr: elasticsearch_filesystem_data_available_bytes{job="{{ include "elasticsearch-monitoring.elasticsearchExporterName" . }}"} / elasticsearch_filesystem_data_size_bytes{job="{{ include "elasticsearch-monitoring.elasticsearchExporterName" . }}"} <= 0.1

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -260,6 +260,10 @@ prometheus-cloudwatch-exporter:
       aws_metric_name: FreeStorageSpace
       aws_dimensions: [ClientId, DomainName]
       aws_statistics: [Minimum, Maximum, Average, Sum]
+    - aws_namespace: AWS/ES
+      aws_metric_name: ClusterIndexWritesBlocked
+      aws_dimensions: [ClientId, DomainName]
+      aws_statistics: [Maximum]
 
   nodeSelector: {}
 


### PR DESCRIPTION
Alert when an ES cluster is blocking write requests. Not sure if it should be critical though...

As per https://github.com/skyscrapers/engineering/issues/478