### PR TITLE
Add intermediate warning alert for velero

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cluster-monitoring
-version: 1.12.7
+version: 1.12.8
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -165,6 +165,16 @@ spec:
       annotations:
         message: Velero backup {{`{{ $labels.schedule }}`}} has {{`{{ $value | humanizePercentage }}`}} volume snapshot failures.
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-velerovolumesnapshotfailures'
+    - alert: VeleroBackupOld
+      expr: |-
+        velero_backup_last_successful_timestamp{schedule="velero-cluster-backup"} + 129600 < time()
+      for: 5m
+      labels:
+        severity: warning
+        group: velero
+      annotations:
+        message: Cluster hasn't been backed up for more than 36 hours.
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-velerobackupold'
     - alert: VeleroBackupTooOld
       expr: |-
         velero_backup_last_successful_timestamp{schedule="velero-cluster-backup"} + 260000 < time()


### PR DESCRIPTION
This will trigger a warning alert when no velero backup has been successfully taken for more than 36 hours

As per https://github.com/skyscrapers/engineering/issues/484