### PR TITLE
Add cert-manager certificate expiring alerts

### DIFF
--- a/cluster-monitoring/Chart.yaml
+++ b/cluster-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cluster-monitoring
-version: 1.12.8
+version: 1.12.9
 description: Cluster-wide monitoring setup using Prometheus-operator and Grafana.
 keywords:
   - grafana

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -108,7 +108,7 @@ spec:
         severity: warning
         group: certificate-status
       annotations:
-        message: 'A cert-manager certificate is expiring'
+        message: 'A cert-manager certificate is about to expire'
         description: 'Certificate {{`{{$labels.name}}`}} will expire in less than two weeks and has not been renewed'
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-about-to-expire'
 ---
@@ -129,38 +129,12 @@ spec:
       expr: certmanager_certificate_expiration_timestamp_seconds < time() + 604800 # one week
       for: 10m
       labels:
-        severity: critical
+        severity: warning
         group: certificate-status
-        namepsace: application-monitoring # This is not necessarly an existing namespace, the label is just meant for routing the cirtical alert
       annotations:
         message: 'A cert-manager certificate is expiring'
         description: 'Certificate {{`{{$labels.name}}`}} will expire in less than one week and has not been renewed'
         runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-expiring'
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: "{{ .Release.Name }}-certificate-status"
-  namespace: "{{ .Release.Namespace }}"
-  labels:
-{{ include "labels" $ | indent 4 }}
-    prometheus: "{{ .Release.Name }}"
-    group: certificate-status
-spec:
-  groups:
-  - name: certmanager-certificate-status.rules
-    rules:
-    - alert: CertificateExpiring
-      expr: certmanager_certificate_expiration_timestamp_seconds < time() + 604800 # one week
-      for: 10m
-      labels:
-        severity: critical
-        group: certificate-status
-        namepsace: application-monitoring
-      annotations:
-        message: 'A cert-manager certificate is expiring'
-        description: 'Certificate {{`{{$labels.name}}`}} will expire in less than one week and has not been renewed'
-        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-expiring'        
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -91,7 +91,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: "{{ .Release.Name }}-certificate-expiring"
+  name: "{{ .Release.Name }}-certificate-about-to-expire"
   namespace: "{{ .Release.Namespace }}"
   labels:
 {{ include "labels" $ | indent 4 }}
@@ -101,7 +101,7 @@ spec:
   groups:
   - name: certmanager-certificate-status.rules
     rules:
-    - alert: CertificateExpiring
+    - alert: CertificateAboutToExpire
       expr: certmanager_certificate_expiration_timestamp_seconds < time() + 1209600 # two weeks
       for: 10m
       labels:
@@ -110,12 +110,12 @@ spec:
       annotations:
         message: 'A cert-manager certificate is expiring'
         description: 'Certificate {{`{{$labels.name}}`}} will expire in less than two weeks and has not been renewed'
-        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-expiring'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-about-to-expire'
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: "{{ .Release.Name }}-certificate-status"
+  name: "{{ .Release.Name }}-certificate-expiring"
   namespace: "{{ .Release.Namespace }}"
   labels:
 {{ include "labels" $ | indent 4 }}
@@ -131,7 +131,7 @@ spec:
       labels:
         severity: critical
         group: certificate-status
-        namepsace: application-monitoring
+        namepsace: application-monitoring # This is not necessarly an existing namespace, the label is just meant for routing the cirtical alert
       annotations:
         message: 'A cert-manager certificate is expiring'
         description: 'Certificate {{`{{$labels.name}}`}} will expire in less than one week and has not been renewed'

--- a/cluster-monitoring/templates/prometheusrule.yaml
+++ b/cluster-monitoring/templates/prometheusrule.yaml
@@ -91,6 +91,80 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  name: "{{ .Release.Name }}-certificate-expiring"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+{{ include "labels" $ | indent 4 }}
+    prometheus: "{{ .Release.Name }}"
+    group: certificate-status
+spec:
+  groups:
+  - name: certmanager-certificate-status.rules
+    rules:
+    - alert: CertificateExpiring
+      expr: certmanager_certificate_expiration_timestamp_seconds < time() + 1209600 # two weeks
+      for: 10m
+      labels:
+        severity: warning
+        group: certificate-status
+      annotations:
+        message: 'A cert-manager certificate is expiring'
+        description: 'Certificate {{`{{$labels.name}}`}} will expire in less than two weeks and has not been renewed'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-expiring'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: "{{ .Release.Name }}-certificate-status"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+{{ include "labels" $ | indent 4 }}
+    prometheus: "{{ .Release.Name }}"
+    group: certificate-status
+spec:
+  groups:
+  - name: certmanager-certificate-status.rules
+    rules:
+    - alert: CertificateExpiring
+      expr: certmanager_certificate_expiration_timestamp_seconds < time() + 604800 # one week
+      for: 10m
+      labels:
+        severity: critical
+        group: certificate-status
+        namepsace: application-monitoring
+      annotations:
+        message: 'A cert-manager certificate is expiring'
+        description: 'Certificate {{`{{$labels.name}}`}} will expire in less than one week and has not been renewed'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-expiring'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: "{{ .Release.Name }}-certificate-status"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+{{ include "labels" $ | indent 4 }}
+    prometheus: "{{ .Release.Name }}"
+    group: certificate-status
+spec:
+  groups:
+  - name: certmanager-certificate-status.rules
+    rules:
+    - alert: CertificateExpiring
+      expr: certmanager_certificate_expiration_timestamp_seconds < time() + 604800 # one week
+      for: 10m
+      labels:
+        severity: critical
+        group: certificate-status
+        namepsace: application-monitoring
+      annotations:
+        message: 'A cert-manager certificate is expiring'
+        description: 'Certificate {{`{{$labels.name}}`}} will expire in less than one week and has not been renewed'
+        runbook_url: 'https://github.com/skyscrapers/documentation/tree/master/runbook.md#alert-name-certificate-expiring'        
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
   name: "{{ .Release.Name }}-external-dns-errors"
   namespace: "{{ .Release.Namespace }}"
   labels:


### PR DESCRIPTION
We have an alert covering when a certificate is not ready, that's more useful for newly created certificates, but for production certificates that fails to renew on time we don't have a way to know beforehand 

These alerts use ` certmanager_certificate_expiration_timestamp_seconds` metric to calculate time left till the certificate expires starting from less than two weeks (normally certificates are renewed one month ahead of their expiring time )

Related issue: https://github.com/skyscrapers/rombit/issues/70

