### PR TITLE
Fix VPA lease checking

### DIFF
--- a/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.9.2
 name: vertical-pod-autoscaler
 type: application
 description: A Helm chart to install vertical-pod-autoscaler inside a Kubernetes cluster.
-version: 0.4.2
+version: 0.4.3
 maintainers:
 - name: skyscrapers
 sources:

--- a/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -41,6 +41,11 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- end }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - name: http
               containerPort: 8080

--- a/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/values.yaml
@@ -27,7 +27,7 @@ recommender:
   extraArgs:
     v: "4"
     pod-recommendation-min-cpu-millicores: 15
-    pod-recommendation-min-memory-mb: 100
+    pod-recommendation-min-memory-mb: 64
   replicaCount: 1
   image:
     # recommender.image.repository -- The location of the recommender image


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->

Apparently the VPA admission controller creates a Lease, which is checked by the updater. If the lease is not valid, the updater won't evict any pods.

By default the Lease will be created in the `kube-system` NS, unless the NAMESPACE environment variable is provided. We were setting this env variable in the admission controller Pod, but not in the updater, which meant that the Lease was being correctly created in the infrastrucutre NS, but the updater was still looking for it in the kube-system NS.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
