### PR TITLE
Adjust cloudwatch exporter region automatically

### DIFF
--- a/aws-rabbitmq-monitoring/Chart.yaml
+++ b/aws-rabbitmq-monitoring/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/aws-rabbitmq-monitoring/values.yaml
+++ b/aws-rabbitmq-monitoring/values.yaml
@@ -53,7 +53,7 @@ prometheus-cloudwatch-exporter:
     create: true
 
   config: |-
-    region: eu-west-1
+    region: {{ .Values.aws.region }}
     period_seconds: 60
     set_timestamp: false
     metrics:

--- a/concourse-monitoring/Chart.yaml
+++ b/concourse-monitoring/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.5.1
 
 dependencies:
   - name: prometheus-cloudwatch-exporter

--- a/concourse-monitoring/values.yaml
+++ b/concourse-monitoring/values.yaml
@@ -48,7 +48,7 @@ prometheus-cloudwatch-exporter:
     create: true
 
   config: |-
-    region: eu-west-1
+    region: {{ .Values.aws.region }}
     period_seconds: 60
     set_timestamp: false
     metrics:

--- a/elasticsearch-monitoring/Chart.yaml
+++ b/elasticsearch-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: ElasticSearch monitoring using Prometheus-operator and Grafana.
 name: elasticsearch-monitoring
 type: application
-version: 1.6.0
+version: 1.6.1
 keywords:
   - grafana
   - kube-prometheus
@@ -15,7 +15,6 @@ sources:
 maintainers:
   - name: skyscrapers
     email: hello@skyscrapers.eu
-engine: gotpl
 dependencies:
   - name: prometheus-elasticsearch-exporter
     version: 4.9.0

--- a/elasticsearch-monitoring/values.yaml
+++ b/elasticsearch-monitoring/values.yaml
@@ -249,7 +249,7 @@ prometheus-cloudwatch-exporter:
 
   config: |-
     # Only get statistics for AWS/ES FreeStorageSpace
-    region: eu-west-1
+    region: {{ .Values.aws.region }}
     period_seconds: 60  # Important to get accurate AWS ES readings
     set_timestamp: false
     metrics:

--- a/mongodb-monitoring/Chart.yaml
+++ b/mongodb-monitoring/Chart.yaml
@@ -14,4 +14,3 @@ sources:
 maintainers:
   - name: skyscrapers
     email: hello@skyscrapers.eu
-engine: gotpl

--- a/rds-monitoring/Chart.yaml
+++ b/rds-monitoring/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.5.1
 
 dependencies:
   - name: prometheus-cloudwatch-exporter

--- a/rds-monitoring/values.yaml
+++ b/rds-monitoring/values.yaml
@@ -55,7 +55,7 @@ prometheus-cloudwatch-exporter:
     create: true
 
   config: |-
-    region: eu-west-1
+    region: {{ .Values.aws.region }}
     period_seconds: 60
     set_timestamp: false
     metrics:

--- a/redshift-monitoring/Chart.yaml
+++ b/redshift-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Redshift monitoring using Prometheus-operator and Grafana.
 name: redshift-monitoring
 type: application
-version: 1.6.0
+version: 1.6.1
 keywords:
   - grafana
   - prometheus-operator

--- a/redshift-monitoring/values.yaml
+++ b/redshift-monitoring/values.yaml
@@ -54,7 +54,7 @@ prometheus-cloudwatch-exporter:
     create: true
 
   config: |-
-    region: eu-west-1
+    region: {{ .Values.aws.region }}
     period_seconds: 60
     set_timestamp: false
     metrics:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->

The prometheus cloudwatch exporter now runs the config through the Helm `tpl` function, so it's now possible to add variables into the config. Before this you'd need to override the full config attribute to change the region.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This was quite error prone, as with some installations we forgot to set the correct region inside the config (only setting it in the `aws` value.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
