### PR TITLE
Switch redshift storage average to cluster

### DIFF
--- a/redshift-monitoring/Chart.yaml
+++ b/redshift-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Redshift monitoring using Prometheus-operator and Grafana.
 name: redshift-monitoring
 type: application
-version: 1.10.2
+version: 1.10.3
 keywords:
   - grafana
   - prometheus-operator

--- a/redshift-monitoring/values.yaml
+++ b/redshift-monitoring/values.yaml
@@ -51,7 +51,7 @@ prometheus-cloudwatch-exporter:
       aws_statistics: [Average]
     - aws_namespace: AWS/Redshift
       aws_metric_name: PercentageDiskSpaceUsed
-      aws_dimensions: [NodeID, ClusterIdentifier]
+      aws_dimensions: [ClusterIdentifier]
       aws_statistics: [Average]
     - aws_namespace: AWS/Redshift
       aws_metric_name: NetworkReceiveThroughput


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
In response to an [on-call alert](https://skyscrapers.slack.com/archives/C02T5U10F/p1697592244928169), we found out we're alerting on disk space usage per individual node, while it'd be more efficient to alert on cluster disk space in general 


# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No GH issue

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested, just checked the alert does exist in CW with the same name on cluster level

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
