### PR TITLE
chore: Update appVersion and version to 1.5.0 in vertical-pod-autoscaler chart

### DIFF
--- a/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.4.1
+appVersion: 1.5.0
 name: vertical-pod-autoscaler
 type: application
 description: A Helm chart to install vertical-pod-autoscaler inside a Kubernetes cluster.
-version: 1.4.1
+version: 1.5.0
 maintainers:
   - name: skyscrapers
 sources:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? Any specific requirements regarding rollout?-->
This PR bumps the VPA to [version 1.5.0](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.5.0).

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/platform/issues/1546

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://docs.skyscrapers.eu/coding_guidelines/git/#pull-requests)
- [ ] My code has been tested: 
  - [ ] Locally (please provide details if applicable)  
  - [ ] In this PR using Atlantis 
- [ ] My code is ready to be applied.  
  - [ ] contains breaking changes 

> [!TIP]
> - If you’ve made any changes to the IaC, you can manually trigger Atlantis to test your changes.
> - Changes to the code in the `terraform/live` folder will automatically trigger Atlantis.
> - If you’ve made changes to the code in the `terraform/modules` folder, you can manually trigger Atlantis by commenting on the PR with: 
`atlantis plan -d terraform/live/<environment>/<project>`.
This command will trigger a plan for the specified project within the specified environment.
