### PR TITLE
chore: Allow overriding certgen image

### DIFF
--- a/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.6.0
 name: vertical-pod-autoscaler
 type: application
 description: A Helm chart to install vertical-pod-autoscaler inside a Kubernetes cluster.
-version: 1.6.0
+version: 1.7.0
 maintainers:
   - name: skyscrapers
 sources:

--- a/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.6.0
 name: vertical-pod-autoscaler
 type: application
 description: A Helm chart to install vertical-pod-autoscaler inside a Kubernetes cluster.
-version: 1.7.0
+version: 1.6.1
 maintainers:
   - name: skyscrapers
 sources:

--- a/vertical-pod-autoscaler/templates/admission-controller-certgen.yaml
+++ b/vertical-pod-autoscaler/templates/admission-controller-certgen.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccountName: {{ include "vpa.fullname" . }}-certgen
       containers:
       - name: certgen
-        image: quay.io/reactiveops/ci-images:v11-alpine
+        image: "{{ .Values.admissionController.certgen.image.repository }}:{{ .Values.admissionController.certgen.image.tag }}"
         command: ["bash"]
         args:
           - -c

--- a/vertical-pod-autoscaler/templates/admission-controller-cleanup.yaml
+++ b/vertical-pod-autoscaler/templates/admission-controller-cleanup.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: {{ include "vpa.fullname" . }}-cleanup
       containers:
       - name: cleanup
-        image: quay.io/reactiveops/ci-images:v11-alpine
+        image: "{{ .Values.admissionController.certgen.image.repository }}:{{ .Values.admissionController.certgen.image.tag }}"
         command: ["bash"]
         args:
           - -c

--- a/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/values.yaml
@@ -111,6 +111,12 @@ admissionController:
     pullPolicy: Always
     # admissionController.image.tag -- Overrides the image tag whose default is the chart appVersion
     tag: ""
+  certgen:
+    image:
+      # admissionController.certgen.image.repository -- The location of the image used by the cert-generation pre-install hook and the post-delete cleanup hook (both share the same image).
+      repository: quay.io/reactiveops/ci-images
+      # admissionController.certgen.image.tag -- The tag of the cert-generation/cleanup image.
+      tag: v11-alpine
   # admissionController.podAnnotations -- Annotations to add to the admission controller pod
   podAnnotations: {}
   # admissionController.priorityClassName -- Priority class to assign to the admission controller pod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? Any specific requirements regarding rollout?-->
This image override was missing.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/platform/issues/1875

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://docs.skyscrapers.eu/docs/how-to-guides/coding_guidelines/git/#pull-requests)
- [ ] My code has been tested: 
  - [ ] Locally (please provide details if applicable)  
  - [ ] In this PR using Atlantis 
- [x] My code is ready to be applied.  
  - [ ] contains breaking changes 

> [!TIP]
> - If you’ve made any changes to the IaC, you can manually trigger Atlantis to test your changes.
> - Changes to the code in the `terraform/live` folder will automatically trigger Atlantis.
> - If you’ve made changes to the code in the `terraform/modules` folder, you can manually trigger Atlantis by commenting on the PR with: 
`atlantis plan -d terraform/live/<environment>/<project>`.
This command will trigger a plan for the specified project within the specified environment.
